### PR TITLE
stop pickarangs from breaking waystones

### DIFF
--- a/overrides/scripts/mod-interaction-bugs/pickarang_waystones.zs
+++ b/overrides/scripts/mod-interaction-bugs/pickarang_waystones.zs
@@ -1,0 +1,24 @@
+import crafttweaker.api.events.CTEventManager;
+import crafttweaker.api.event.block.BlockBreakEvent;
+// bug: pickarangs can break waystones, including naturally generated ones. 
+// disables pickarangs from breakiong all waystones.
+
+var rangs = [
+  <item:quark:pickarang>,
+  <item:quark:flamerang>,
+  <item:quark:echorang>,
+];
+
+CTEventManager.register<BlockBreakEvent>((event) => {
+  var block = event.getBlockState().block;
+  if !block.matches(<block:waystones:waystone>) {
+    return;
+  }
+  var tool = event.getPlayer().getMainHandItem().asIItemStack().anyDamage();
+  for rang in rangs {
+    if tool.matches(rang) {
+      event.cancel();
+      return;
+    }
+  }
+});


### PR DESCRIPTION
closes #200 

stops pickarangs from breaking waystones. this stops the ability to steal waystones from villages and also will stop from accidentally breaking a waystone if a player tries to right click it from too far away.