### PR TITLE
move diet mod button to the left so it doesnt overlap with magnet rin…

### DIFF
--- a/overrides/config/diet-client.toml
+++ b/overrides/config/diet-client.toml
@@ -2,7 +2,7 @@
 addButton = true
 #The x-position of the Diet GUI button in player inventories.
 #Range: -10000 ~ 10000
-buttonX = 126
+buttonX = 100
 #The y-position of the Diet GUI button in player inventories.
 #Range: -10000 ~ 10000
 buttonY = -22


### PR DESCRIPTION
closes #80 

move diet mod button to the left a little so it doesn't overlap with magnet ring button. not sure what other button might appear in inv 