### PR TITLE
ban logs from multimine

### DIFF
--- a/overrides/config/multimine.cfg
+++ b/overrides/config/multimine.cfg
@@ -4,6 +4,7 @@
   "blockRegenIntervalMillis": 1000,
   "debugMode": false,
   "bannedBlocks": {
+    "minecraft:logs": true,
     "treechop:chopped_log": false,
     "minecraft:acacia_log": false,
     "minecraft:coarse_dirt": false,


### PR DESCRIPTION
partially closes #236 

fixes issue where treechop only worked when using multimine to start and stop chopping

I just blacklisted logs from multimine as is the recommended fix by multimine.