### PR TITLE
track zips with git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Large files
-*.zip
 *.7z
 .obsidian/workspace.json
 
@@ -21,4 +20,5 @@ overrides/simplebackups/
 overrides/config/jei/world/
 overrides/shaderpacks/ComplementaryReimagined_r5.0.1.zip.txt
 overrides/config/blockswap/known_states/
+Chocolate-Edition.zip
 *.bak

--- a/overrides/config/paxi/datapacks/ChocoStructures.zip
+++ b/overrides/config/paxi/datapacks/ChocoStructures.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d756e56bdded346d4290b47ccbdfb72c6ac542e63d4f23c75d2bbbf3ed9c31c7
+size 546950

--- a/overrides/config/paxi/datapacks/ChocolateyFlavour.zip
+++ b/overrides/config/paxi/datapacks/ChocolateyFlavour.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24a6fad9b8f9876a3c3372dc766c1adf4db938d20260cad2ca05650f1c2c6814
+size 12568

--- a/overrides/config/paxi/datapacks/WDA-NoFlyingStructures-1.18.2-1.19.2.zip
+++ b/overrides/config/paxi/datapacks/WDA-NoFlyingStructures-1.18.2-1.19.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78bee139bb66deba62bb3671203556e8a03f306aac320030242e29ac4ead60bf
+size 18424

--- a/overrides/config/paxi/datapacks/WDA-VanillaLoot-1.18.2-1.19.2-0.0.1.zip
+++ b/overrides/config/paxi/datapacks/WDA-VanillaLoot-1.18.2-1.19.2-0.0.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bbcaca8a773be45a2f3f7e04c344d418f797641311d8b9f312bce829858edcb
+size 107783

--- a/overrides/config/paxi/datapacks/bcrange.zip
+++ b/overrides/config/paxi/datapacks/bcrange.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04b41a74a6d21a4785c03aa6205bf2b885093b71112035d4731b72e9cea10979
+size 13761

--- a/overrides/config/paxi/datapacks/chocompatv1.2.zip
+++ b/overrides/config/paxi/datapacks/chocompatv1.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6a3ff5fece93d50f6def56d6a6a81bd6854c39c1eebba3eb81eb2500fa5dab9
+size 99629450

--- a/overrides/config/paxi/datapacks/ctov-3-2-3edited.zip
+++ b/overrides/config/paxi/datapacks/ctov-3-2-3edited.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2788bfda1c8c6c76f79ba932dcce1b4fc808d57abca8427f045dbe6103b892e
+size 3625463

--- a/overrides/config/paxi/datapacks/idasalexsmobs-1.7.5-1.19.2.zip
+++ b/overrides/config/paxi/datapacks/idasalexsmobs-1.7.5-1.19.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15cf56e84d4c7176a5cdd8570a5fb1b6df6225257f43783c1e7758073db35e26
+size 188597

--- a/overrides/config/paxi/datapacks/idasconfig1.7.6-1.19.2.zip
+++ b/overrides/config/paxi/datapacks/idasconfig1.7.6-1.19.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acaa5779a0ad3bc881d141c86ddc64913c079c767643a99a4d2ddd479e9c7390
+size 4212159

--- a/overrides/config/paxi/datapacks/intstrong_dungeonsmobs-1.0.0-1.18.2-1.19.2.zip
+++ b/overrides/config/paxi/datapacks/intstrong_dungeonsmobs-1.0.0-1.18.2-1.19.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0435326c6ef8f077e17e8c4bbe7c69b3e6f120d9b3e0b54c45f2db08919c80e3
+size 2534

--- a/overrides/config/paxi/datapacks/intstrong_endrem-1.0.0-1.18.2-1.19.2.zip
+++ b/overrides/config/paxi/datapacks/intstrong_endrem-1.0.0-1.18.2-1.19.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e41b8cc5e0e255f8639c0a1ee76aa37486fa0c7d406976983c53a6c56438bbb
+size 654

--- a/overrides/config/paxi/datapacks/norundownhouse-1.19.4.zip
+++ b/overrides/config/paxi/datapacks/norundownhouse-1.19.4.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e69717e9b3c2edff33f88e3a43364ad92def665adb8f500c84c93fe150d2cece
+size 512

--- a/overrides/config/paxi/datapacks/queen_bee_jungle.zip
+++ b/overrides/config/paxi/datapacks/queen_bee_jungle.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35abced1629ea17d6fb14d652b176b3717aaaf1dcafe0253041001abc78d672
+size 6236

--- a/overrides/config/paxi/datapacks/totemcharm.zip
+++ b/overrides/config/paxi/datapacks/totemcharm.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bdd8095c7b548b9cf3a86e685432096d07595587e1ae1cc5ae24334df470f2e
+size 1468

--- a/overrides/config/paxi/datapacks/wdaspacingtweaked.zip
+++ b/overrides/config/paxi/datapacks/wdaspacingtweaked.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9220af6e1e04aa03f0203f79587f64aecee5ba1ab6323f4950a059b2a7e72d24
+size 17497

--- a/overrides/config/paxi/resourcepacks/Alexish Mobs v1.0.zip
+++ b/overrides/config/paxi/resourcepacks/Alexish Mobs v1.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:533b3081ebb13be18ad8b065c65d0819cb112e1bd8113de77389ff04305a8648
+size 192432

--- a/overrides/config/paxi/resourcepacks/Create Style Modded Compats v16.zip
+++ b/overrides/config/paxi/resourcepacks/Create Style Modded Compats v16.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c55adaae45cf72500999fa8763d7709bbdbecb6ade653c76586ee3be2eca30b6
+size 368266

--- a/overrides/config/paxi/resourcepacks/Dark_transparent_Menu_UI.zip
+++ b/overrides/config/paxi/resourcepacks/Dark_transparent_Menu_UI.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:980222ad54c9b6bd20203a5169c865c92e2089611fbb6886ad2614bda97d9de6
+size 38944

--- a/overrides/config/paxi/resourcepacks/EclecticTrove-noconfig-1.19-1.2.0.zip
+++ b/overrides/config/paxi/resourcepacks/EclecticTrove-noconfig-1.19-1.2.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebbbb5006ec55769913c20d5600afbd67aaf7a893a8923453d3b4a2c1b441693
+size 9480

--- a/overrides/config/paxi/resourcepacks/MandalasGUI_Legacy+Modded_Dakmode_v4.2.zip
+++ b/overrides/config/paxi/resourcepacks/MandalasGUI_Legacy+Modded_Dakmode_v4.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:220b48251c7cd349563d08aa7ec5a8ca33460b95544d342c87756658ae830dd6
+size 1023634

--- a/overrides/config/paxi/resourcepacks/OLG_1.1.3_1.16+.zip
+++ b/overrides/config/paxi/resourcepacks/OLG_1.1.3_1.16+.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e762d75fb388a063af0537a69d77bace526240967c9832635f3f4890cf244963
+size 17990

--- a/overrides/config/paxi/resourcepacks/Realistic Combat Soundpack 1.19.2.zip
+++ b/overrides/config/paxi/resourcepacks/Realistic Combat Soundpack 1.19.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60f18fc37710fa6ffc529ab1e7e1400914a63487ef5260859ea6015bd6476574
+size 941200

--- a/overrides/config/paxi/resourcepacks/Vibrating Wither Fix.zip
+++ b/overrides/config/paxi/resourcepacks/Vibrating Wither Fix.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9698acaa11b61ae29a7e0966ba4502eedbe29e99aa0c7eae39dd864e82d9d84e
+size 2017

--- a/overrides/config/paxi/resourcepacks/Visualtitles+Choc.zip
+++ b/overrides/config/paxi/resourcepacks/Visualtitles+Choc.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d71266533690b6f0984a3811b7257b456abca3f7e44be53beea5857997107d3
+size 319619

--- a/overrides/config/paxi/resourcepacks/[1.3] Enhanced Boss Bars.zip
+++ b/overrides/config/paxi/resourcepacks/[1.3] Enhanced Boss Bars.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50452f0e5becf56defe3e9cb1ca9c855c1af51bc8993b6daddad94e17bdcb329
+size 135393

--- a/overrides/config/paxi/resourcepacks/chocompatv1.1.zip
+++ b/overrides/config/paxi/resourcepacks/chocompatv1.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbaa3b5813c009cae37ef946b1f7945d47464244529d359ed6625bb9fb785f6e
+size 99625275

--- a/overrides/config/towns_and_towers/resources/t_and_t_waystones_patch_1.19.2.zip
+++ b/overrides/config/towns_and_towers/resources/t_and_t_waystones_patch_1.19.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06f47bd0839fb1c2ab27a34d277fda83db1c67d2602c70a43aa7b8eb0a4d8915
+size 33649

--- a/overrides/resourcepacks/Infernal Resources.zip
+++ b/overrides/resourcepacks/Infernal Resources.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8f9ad919602ab59a672e8c9efc34a2e6c402c2436471e3ce7faf4134a41c466
+size 27230

--- a/overrides/resourcepacks/Quark Programmer Art.zip
+++ b/overrides/resourcepacks/Quark Programmer Art.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41cb720cf256a12ea247b2f38068b363aa5b1675470c4b5aa66850701a78bc4d
+size 266434

--- a/overrides/resourcepacks/norundownhouse-1.19.4.zip
+++ b/overrides/resourcepacks/norundownhouse-1.19.4.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e69717e9b3c2edff33f88e3a43364ad92def665adb8f500c84c93fe150d2cece
+size 512

--- a/overrides/scripts/ComplementaryReimagined_r5.0.1.zip
+++ b/overrides/scripts/ComplementaryReimagined_r5.0.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8ad0b1ca8bd9df23b84a29be08c4a00730083ee7d142b0b2c23d0d4bd44ccaf
+size 402256


### PR DESCRIPTION
uploaded all the zips with git lfs.

we should be able to get away with it on the free plan as total size is like 150 MB and we get up to 1gb.

you may need to install git lfs locally 
https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage

this way it should be possible to track changes to zips on git "the right way"

it unfortunately wont show the actual changes made to files inside the zip but at least the changes can be shared. plus we'll be able to properly use the repo as a profile import 