### PR TITLE
Remove Wither Scuttler from Arthropod Quest

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/quests.snbt
+++ b/overrides/config/ftbquests/quests/chapters/quests.snbt
@@ -12127,19 +12127,6 @@
 					value: 10L
 				}
 				{
-					entity: "born_in_chaos_v1:wither_scuttler"
-					icon: {
-						Count: 1b
-						ForgeCaps: {
-							"dungeons_libraries:built_in_enchantments": { }
-						}
-						id: "born_in_chaos_v1:wither_scuttler_spawn_egg"
-					}
-					id: "1D8BD46F5515F02D"
-					type: "kill"
-					value: 5L
-				}
-				{
 					entity: "crittersandcompanions:dragonfly"
 					icon: {
 						Count: 1b


### PR DESCRIPTION
the Wither Scuttler is being removed from the new version of born in chaos so I remove it too from the quests