### PR TITLE
add tetra tuning

### DIFF
--- a/overrides/config/paxi/datapacks/tetra tuning.zip
+++ b/overrides/config/paxi/datapacks/tetra tuning.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f40d2f6010d45a727cdb49656da454020898d9de42b8744f18d86143c8c24e4e
+size 3454


### PR DESCRIPTION
- changed the damage scalar of rapiers from 70% to 50%. changed the base armor pen from 2% to 15%
- changed amethyst socket reaching % from 21% to 11%
- removed the crit% critdamage% from amethyst steel
- closes #401 