### PR TITLE
adds the datapack for removing parcools hidden advancement that grant…

### DIFF
--- a/overrides/config/paxi/datapacks/byeparcoolbook.zip
+++ b/overrides/config/paxi/datapacks/byeparcoolbook.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3842b4372096d50c455084e6f83797cacc308d4920c3b357ef8a399b25da756
+size 614


### PR DESCRIPTION
…s the book

is a 0 line datapack that just removes a hidden advancement that on tick gives the parcool book

didn't know the commit would bleed the title into the description like that 😭 