### PR TITLE
Bug/disable mummy

### DIFF
--- a/overrides/config/incontrol/spawn.json
+++ b/overrides/config/incontrol/spawn.json
@@ -2336,5 +2336,9 @@
   {
     "mob": ["alexsmobs:underminer"],
     "result": "deny"
+  },
+  {
+    "mob": ["rottencreatures:mummy"],
+    "result": "deny"
   }
 ]


### PR DESCRIPTION
closes #508 

I checked the rotten creatures mod page and github, they said they would fix it in an update, but that was said last year and no new update has been available for 1.19.2 since 2022. so I think at this point disabling the mummies is our only shot.

seems to work, stopping mummy spawners from spawning them in the idas serpent labyrinth