### PR TITLE
alex mobs drop fix

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/hard_eyes.snbt
+++ b/overrides/config/ftbquests/quests/chapters/hard_eyes.snbt
@@ -3650,7 +3650,7 @@
 		}
 		{
 			dependencies: ["5DA4FF9594050625"]
-			description: ["This item can be obtained by killing &cSoul Vultures&r, which spawns in the Soul Sand Valley. &eSoul Hearts&r can only be obtained onbce a &cSoul Vulture&r has sucked the soul from its victium five times. they must be damaged for the soul steal to happen. the soul heart has a 20% drop rate."]
+			description: ["This item can be obtained by killing &cSoul Vultures&r, which spawns in the Soul Sand Valley. &eSoul Hearts&r can only be obtained onbce a &cSoul Vulture&r has sucked the soul from its victium five times. when the soul vulture is below half health and attacks you, they will heal some hp. after doing so 5 times their wings will glow blue, and they will drop a soul heart when killed."]
 			id: "67DE26F4537FDCC7"
 			subtitle: "Dropped by Soul Vultures"
 			tasks: [{

--- a/overrides/config/ftbquests/quests/chapters/medium_eyes.snbt
+++ b/overrides/config/ftbquests/quests/chapters/medium_eyes.snbt
@@ -343,7 +343,7 @@
 		}
 		{
 			dependencies: ["3901079844A43EC1"]
-			description: ["This item can be obtained by playing a &eMaraca&r while near &aCockroach&r and killing it while it dances. "]
+			description: ["This item can be obtained by giving a &eMaraca&r to a &aCockroach&r and killing it while it dances. "]
 			id: "18C7095EA653E6A0"
 			rewards: [
 				{

--- a/overrides/config/paxi/datapacks/chocmobs.zip
+++ b/overrides/config/paxi/datapacks/chocmobs.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a751c615562de7aae989cfa191a0f214e3596d500175f70372bc00157b49318
+size 1832

--- a/overrides/config/spark/activity.json
+++ b/overrides/config/spark/activity.json
@@ -1,15 +1,1 @@
-[
-  {
-    "user": {
-      "type": "player",
-      "name": "Edward_the_llama",
-      "uniqueId": "5d26ef8d-6337-4a95-b2ac-1f60355d560d"
-    },
-    "time": 1719002960077,
-    "type": "Profiler",
-    "data": {
-      "type": "url",
-      "value": "https://spark.lucko.me/ry3udpSSbj"
-    }
-  }
-]
+[]


### PR DESCRIPTION
datapack that changes the min drop of soul vulture heart to 1 instead of 0. and changes sombrero droprate to 100% instead of 20%. changes looting multiplier from 1% to 20% on sombrero but that didn't work, don't see it causing problems so just left it in.