### PR TITLE
disable all toasts for particles settings quests

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/settings.snbt
+++ b/overrides/config/ftbquests/quests/chapters/settings.snbt
@@ -27,6 +27,7 @@
 				ignore_reward_blocking: true
 				silent: true
 				team_reward: false
+				title: "On"
 				type: "command"
 			}]
 			size: 3.0d
@@ -51,6 +52,7 @@
 				ignore_reward_blocking: true
 				silent: true
 				team_reward: false
+				title: "On"
 				type: "command"
 			}]
 			size: 3.0d
@@ -75,6 +77,7 @@
 				ignore_reward_blocking: true
 				silent: true
 				team_reward: false
+				title: "On"
 				type: "command"
 			}]
 			size: 3.0d
@@ -124,6 +127,7 @@
 				ignore_reward_blocking: true
 				silent: true
 				team_reward: false
+				title: "Off"
 				type: "command"
 			}]
 			size: 3.0d
@@ -148,6 +152,7 @@
 				ignore_reward_blocking: true
 				silent: true
 				team_reward: false
+				title: "Off"
 				type: "command"
 			}]
 			size: 3.0d

--- a/overrides/config/ftbquests/quests/chapters/settings.snbt
+++ b/overrides/config/ftbquests/quests/chapters/settings.snbt
@@ -31,6 +31,7 @@
 			}]
 			size: 3.0d
 			tasks: [{
+				disable_toast: true
 				id: "14A81C6A83A447AE"
 				title: "Meadow Wind Particles On"
 				type: "checkmark"
@@ -54,6 +55,7 @@
 			}]
 			size: 3.0d
 			tasks: [{
+				disable_toast: true
 				id: "0D454B0F185F8E6E"
 				title: "Everbright Snow Particles On"
 				type: "checkmark"
@@ -77,6 +79,7 @@
 			}]
 			size: 3.0d
 			tasks: [{
+				disable_toast: true
 				id: "2550CC6C0E83B07D"
 				title: "Everdawn Smoke Particles On"
 				type: "checkmark"
@@ -101,6 +104,7 @@
 			}]
 			size: 3.0d
 			tasks: [{
+				disable_toast: true
 				id: "60FE486A907EFED1"
 				title: "Meadow Wind Particles Off"
 				type: "checkmark"
@@ -124,6 +128,7 @@
 			}]
 			size: 3.0d
 			tasks: [{
+				disable_toast: true
 				id: "18987CDC5EF766E3"
 				title: "Everbright Snow Particles Off"
 				type: "checkmark"
@@ -147,6 +152,7 @@
 			}]
 			size: 3.0d
 			tasks: [{
+				disable_toast: true
 				id: "0A9717BD7B1820A5"
 				title: "Everdawn Smoke Particles Off"
 				type: "checkmark"

--- a/overrides/config/ftbquests/quests/chapters/temps.snbt
+++ b/overrides/config/ftbquests/quests/chapters/temps.snbt
@@ -2645,6 +2645,7 @@
 		{
 			can_repeat: true
 			dependencies: ["177CCA876BBC9A3E"]
+			disable_toast: true
 			id: "5B584CE502BC9124"
 			rewards: [
 				{
@@ -2701,6 +2702,7 @@
 		{
 			can_repeat: true
 			dependencies: ["572E7C8B81EA10ED"]
+			disable_toast: true
 			id: "71205726B9342781"
 			rewards: [{
 				auto: "no_toast"
@@ -2725,6 +2727,7 @@
 		{
 			can_repeat: true
 			dependencies: ["5E0D0EFACA192EEB"]
+			disable_toast: true
 			id: "6FB30BCA8CBF9926"
 			rewards: [
 				{
@@ -3759,6 +3762,7 @@
 			y: 4.75d
 		}
 		{
+			disable_toast: true
 			id: "24EC36810521746E"
 			rewards: [{
 				auto: "no_toast"
@@ -3775,6 +3779,7 @@
 			y: -4.5d
 		}
 		{
+			disable_toast: true
 			id: "3F177169BF9FE9F1"
 			rewards: [{
 				auto: "no_toast"
@@ -3791,6 +3796,7 @@
 			y: -4.5d
 		}
 		{
+			disable_toast: true
 			id: "1AEB21C9EF089CCC"
 			rewards: [{
 				auto: "no_toast"

--- a/overrides/config/ftbquests/quests/chapters/temps.snbt
+++ b/overrides/config/ftbquests/quests/chapters/temps.snbt
@@ -2690,10 +2690,9 @@
 				}
 			]
 			tasks: [{
-				id: "54FD6BC16EFF0D1F"
-				stat: "minecraft:walk_one_cm"
-				type: "stat"
-				value: 1
+				biome: "#blue_skies:everbright"
+				id: "2A25D06941498859"
+				type: "biome"
 			}]
 			title: "Everbright snow particle"
 			x: 8.25d
@@ -2715,10 +2714,9 @@
 				type: "command"
 			}]
 			tasks: [{
-				id: "54D662D096636C13"
-				stat: "minecraft:walk_one_cm"
-				type: "stat"
-				value: 1
+				biome: "#blue_skies:everdawn"
+				id: "7DA61A5BF57C66A8"
+				type: "biome"
 			}]
 			title: "Everdawn Dust particle"
 			x: 9.5d


### PR DESCRIPTION
toasts for the particles settings would still appear when joining a world for the first time. this fixes that

related to #637 