### PR TITLE
disable seagul stealing

### DIFF
--- a/src/overrides/config/alexsmobs.toml
+++ b/src/overrides/config/alexsmobs.toml
@@ -92,7 +92,7 @@
 	#Whether the void worm boss is summonable or not, via the mysterious worm item.
 	voidWormSummonable = true
 	#Whether seagulls should steal food out of players' hotbar slots.
-	seagullStealing = true
+	seagullStealing = false
 	#List of items that seagulls cannot take from players.
 	seagullStealingBlacklist = []
 	#Whether the Clinging Potion effect should flip the screen. Warning: may cause nausea.
@@ -688,4 +688,3 @@
 			[general.spawning.uniqueSpawning.dangerZone]
 				#Its been so long...
 				superSecretSettings = false
-


### PR DESCRIPTION
closes #616 

figured its probably best to disable it altogether as anyone wanting to set up base near a beach will have a bad time regardless what food they use.