### PR TITLE
add 3 minute delay between songs in the same pool

### DIFF
--- a/src/overrides/config/MusicTriggers/Chocolate/main.toml
+++ b/src/overrides/config/MusicTriggers/Chocolate/main.toml
@@ -245,7 +245,7 @@
 		fade_out = "80"
 		persistence = "0"
 		trigger_delay = "0"
-		song_delay = "0"
+		song_delay = "7200"
 		start_delay = "0"
 		stop_delay = "0"
 		fade_in = "20"


### PR DESCRIPTION
closes #725 

normal minecraft has like 10 mins between songs. this should be more reasonable so even if you spend a while in the same biome you arent hearing the same tracks on repeat one after the other. a little bit of silence should be nice !