### PR TITLE
adds shaded citadel to the rotation whitelist

### DIFF
--- a/src/overrides/config/paxi/datapacks/ChocoStructuresRotFix/data/structure_no_rotate/tags/worldgen/template_pool/do_not_rotate.json
+++ b/src/overrides/config/paxi/datapacks/ChocoStructuresRotFix/data/structure_no_rotate/tags/worldgen/template_pool/do_not_rotate.json
@@ -1,0 +1,28 @@
+{
+  "values": [
+    {
+      "id": "chocolate:white_palace/white_palace_left",
+      "required": false
+    },
+    {
+      "id": "chocolate:white_palace/white_palace_middle",
+      "required": false
+    },
+    {
+      "id": "chocolate:white_palace/white_palace_middle_bottom",
+      "required": false
+    },
+    {
+      "id": "chocolate:white_palace/white_palace_right",
+      "required": false
+    },  
+	{
+      "id": "chocolate:shaded_citadel",
+      "required": false
+    },
+    {
+      "id": "chocolate:white_palace/white_palace_basement",
+      "required": false
+    }
+  ]
+}

--- a/src/overrides/config/paxi/datapacks/ChocoStructuresRotFix/pack.mcmeta
+++ b/src/overrides/config/paxi/datapacks/ChocoStructuresRotFix/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "pack_format": 10,
+        "description": "rotation fix dp for chocolate structures"
+    }
+}


### PR DESCRIPTION
it has all the white palace jigsaws too cause didn't really want to test if having the datapack have everything/just shaded citadel overwrote anything. the mod has all the white palace ones in it already so the white palace was always fine on this update.

separate datapack since don't know if it breaks if the mods not present

closes #781 