### PR TITLE
Added waystone dimension rewards

### DIFF
--- a/src/overrides/config/ftbquests/quests/chapters/aether.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/aether.snbt
@@ -23,6 +23,11 @@
 		}
 		id: "1586FC76858DC429"
 		invisible: true
+		rewards: [{
+			id: "3E00A6A582A666E1"
+			item: "waystones:waystone"
+			type: "item"
+		}]
 		size: 5.0d
 		subtitle: "The Realm of Genesis, mythic skies ruled by divine forces seeking justice and purity."
 		tasks: [{

--- a/src/overrides/config/ftbquests/quests/chapters/end.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/end.snbt
@@ -16,6 +16,11 @@
 		}
 		id: "55BA9E32C79162F5"
 		invisible: true
+		rewards: [{
+			id: "448655442033F405"
+			item: "waystones:waystone"
+			type: "item"
+		}]
 		size: 5.0d
 		subtitle: "The Realm of Space, blending extremities of endless void and living off mystical energies."
 		tasks: [{

--- a/src/overrides/config/ftbquests/quests/chapters/everdawn__everbright.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/everdawn__everbright.snbt
@@ -7,23 +7,28 @@
 	id: "513B88027767E135"
 	order_index: 6
 	quest_links: [ ]
-	quests: [{
-		dependency_requirement: "one_completed"
-		hide: true
-		icon: {
-			Count: 1b
-			id: "ftbquests:custom_icon"
-			tag: {
-				Icon: "enlightened_end:items/empty_everglint_mirror"
+	quests: [
+		{
+			dependency_requirement: "one_completed"
+			hide: true
+			icon: {
+				Count: 1b
+				id: "ftbquests:custom_icon"
+				tag: {
+					Icon: "enlightened_end:items/empty_everglint_mirror"
+				}
 			}
-		}
-		id: "002119AE11735C80"
-		invisible: true
-		invisible_until_tasks: 1
-		size: 5.0d
-		subtitle: "Distorted Realms of Light and Dark, simultaneously prehistoric and everlasting."
-		tasks: [
-			{
+			id: "002119AE11735C80"
+			invisible: true
+			invisible_until_tasks: 1
+			rewards: [{
+				id: "3A50EF61FD3573F3"
+				item: "waystones:waystone"
+				type: "item"
+			}]
+			size: 5.0d
+			subtitle: "Distorted Realms of Light and Dark, simultaneously prehistoric and everlasting."
+			tasks: [{
 				dimension: "blue_skies:everbright"
 				icon: {
 					Count: 1b
@@ -34,8 +39,32 @@
 				}
 				id: "1F7AA9CFCB617A97"
 				type: "dimension"
+			}]
+			title: "Everbright"
+			x: 0.0d
+			y: 0.0d
+		}
+		{
+			dependency_requirement: "one_completed"
+			hide: true
+			icon: {
+				Count: 1b
+				id: "ftbquests:custom_icon"
+				tag: {
+					Icon: "enlightened_end:items/empty_everglint_mirror"
+				}
 			}
-			{
+			id: "08EBAC5620061699"
+			invisible: true
+			invisible_until_tasks: 1
+			rewards: [{
+				id: "716D5E5C00A9DAF5"
+				item: "waystones:waystone"
+				type: "item"
+			}]
+			size: 5.0d
+			subtitle: "Distorted Realms of Light and Dark, simultaneously prehistoric and everlasting."
+			tasks: [{
 				dimension: "blue_skies:everdawn"
 				icon: {
 					Count: 1b
@@ -44,13 +73,13 @@
 						Icon: "blue_skies:block/portal/everdawn_portal"
 					}
 				}
-				id: "3F62B00F0F96C510"
+				id: "3B1DE078D7D568D6"
 				type: "dimension"
-			}
-		]
-		title: "Everdawn - Everbright"
-		x: 0.5d
-		y: 0.25d
-	}]
+			}]
+			title: "Everdawn"
+			x: 6.25d
+			y: 0.0d
+		}
+	]
 	title: "&bEverdawn - &cEverbright"
 }

--- a/src/overrides/config/ftbquests/quests/chapters/nether.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/nether.snbt
@@ -16,6 +16,11 @@
 		}
 		id: "51D2618414C8D9EA"
 		invisible: true
+		rewards: [{
+			id: "00276539921AA1F9"
+			item: "waystones:waystone"
+			type: "item"
+		}]
 		size: 5.0d
 		subtitle: "The Realm of Chaos, where cthonic and primordial forces bubble and broil."
 		tasks: [{

--- a/src/overrides/config/ftbquests/quests/chapters/nexus.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/nexus.snbt
@@ -23,6 +23,11 @@
 		}
 		id: "64C7C18D4EFA7E5D"
 		invisible: true
+		rewards: [{
+			id: "728C196106D2F583"
+			item: "waystones:waystone"
+			type: "item"
+		}]
 		size: 5.0d
 		subtitle: "The Realm of Time, the cogs and wheels between the dimensions, able to access ones even beyond our understanding..."
 		tasks: [{

--- a/src/overrides/config/ftbquests/quests/chapters/overworld.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/overworld.snbt
@@ -19,6 +19,11 @@
 		id: "1F52C530B9B34012"
 		invisible: true
 		invisible_until_tasks: 1
+		rewards: [{
+			id: "04DC5E25A6B6AD0E"
+			item: "waystones:waystone"
+			type: "item"
+		}]
 		size: 5.0d
 		subtitle: "The Realm of Origin, which all other realms are based on."
 		tasks: [{

--- a/src/overrides/config/ftbquests/quests/chapters/useful_items.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/useful_items.snbt
@@ -1181,28 +1181,6 @@
 		}
 		{
 			disable_toast: true
-			icon: "waystones:waystone"
-			id: "0033D56F43CF73BC"
-			rewards: [{
-				id: "5578CAF9467D49D8"
-				item: {
-					Count: 1b
-					ForgeCaps: {
-						"dungeons_libraries:built_in_enchantments": { }
-					}
-					id: "waystones:waystone"
-				}
-				type: "item"
-			}]
-			shape: "square"
-			size: 3.0d
-			subtitle: "Place it only once for your base. That is the intended experience; however if you end up carrying it around with you, i can't stop you."
-			title: "Free waystone for your base!"
-			x: 4.5d
-			y: 10.5d
-		}
-		{
-			disable_toast: true
 			icon: "iter_rpg:big_vase"
 			id: "03E1F82B1F4D6090"
 			shape: "square"


### PR DESCRIPTION
Also removed free waystone from useful items

I didn't change the descriptions of the Everdawn/Everbright split entries, but can do so if needed. I figure they'd both need to be updated to something relating more unique to each dimension now.

Solves #754 