### PR TITLE
Updated the descriptions of artifacts umbrella

### DIFF
--- a/src/overrides/config/ftbquests/quests/chapters/useful_items.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/useful_items.snbt
@@ -975,6 +975,7 @@
 		}
 		{
 			dependencies: ["3291DD3425A92D43"]
+			description: ["Note: The shield functionality of this item has been disabled due to it having infinite durability."]
 			id: "2542A4FE57D3622A"
 			rewards: [{
 				id: "4491AE05597258D1"
@@ -982,6 +983,7 @@
 				xp: 300
 			}]
 			shape: "square"
+			subtitle: "I'm Mary Poppins, Y'all!"
 			tasks: [{
 				id: "23298698784D3EBD"
 				item: {

--- a/src/overrides/config/paxi/resourcepacks/choccompatv1.3/assets/artifacts/lang/en_us.json
+++ b/src/overrides/config/paxi/resourcepacks/choccompatv1.3/assets/artifacts/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+    "item.artifacts.umbrella.tooltip": "can be used as a glider"
+}

--- a/src/overrides/config/paxi/resourcepacks/choccompatv1.3/assets/chocolate/lang/en_us.json
+++ b/src/overrides/config/paxi/resourcepacks/choccompatv1.3/assets/chocolate/lang/en_us.json
@@ -15,6 +15,7 @@
     "jei_desc.chocolate.infusion_table_2": "Enchantment transferral is done with the following steps:\n1. Place a book on the table. \n2. Place an enchanted item on the table. \n3. Use a Flint and Steel on the table. \n4. Punch the table once the particles subside.",
     "jei_desc.chocolate.backpack_encumbering": "If you're carrying more than one backpack, a Slowness effect will be applied.",
     "jei_desc.chocolate.artifact_repair": "Artifacts can be repaired in an Anvil using Dubious Dust, which can be crafted from other Artifacts at any durability.",
+    "jei_desc.chocolate.umbrella": "Note: The shield functionality of this item has been disabled due to it having infinite durability.",
     "jei_desc.chocolate.ignis_summon": "Place Burning Ashes on the Altar of Fire to summon Ignis.",
     "jei_desc.chocolate.leviathan_summon": "Place an Abyssal Sacrifice on the Altar of Abyss to summon the Leviathan.",
     "jei_desc.chocolate.crab_meat_blessing": "Place Amethyst Crab Meat on the Altar of Amethyst to bless it.",

--- a/src/overrides/scripts/item_descriptions.zs
+++ b/src/overrides/scripts/item_descriptions.zs
@@ -115,6 +115,10 @@ i(<item:minecraft:green_candle>, "green_candle");
 i(<item:minecraft:red_candle>, "red_candle");
 i(<item:minecraft:black_candle>, "black_candle");
 
+// ----- Artifacts -----
+
+i(<item:artifacts:umbrella>, "umbrella");
+
 // ----- Blue Skies -----
 
 


### PR DESCRIPTION
Updated the QB and added a JEI page to reflect the shield functionality of the umbrella being disabled. I would remove the item description upon hover and the page that adds the description saying it can be used as a glider and shield, but I don't believe there is a way with CraftTweaker to do this currently.

closes #580 