### PR TITLE
Add precision mechanism to crafting table

### DIFF
--- a/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
@@ -1603,6 +1603,8 @@
 				"This item is obtained by processing a &eGold Sheet&r by adding an &eIron Nugget&r, a &eCogwheel&r, and a &eLarge Cogwheel&r using &eDeployers&r. This process must be repeated five times, and has a 20% chance to fail. For more information, use the Ponder mechanic on the &eDeployer&r."
 				""
 				"The Precision Mechanism is fairly tedious to make, but it is used a variety of extremely powerful Create tools such as the &eRotation Speed Controller&r, the &eExtendo-Grip&r, the &eWand of Symmetry&r, and others."
+				""
+				"&oThere is an alternative crafting recipe to craft this for those who are not interested in sequenced assembly.&r"
 			]
 			id: "305E7EC139FEE651"
 			rewards: [

--- a/src/overrides/scripts/recipes/create/precision_mechanism.zs
+++ b/src/overrides/scripts/recipes/create/precision_mechanism.zs
@@ -1,0 +1,5 @@
+craftingTable.addShaped("precision_mechanism", <item:create:precision_mechanism>, [
+  [<item:create:golden_sheet>, <item:create:deployer>.reuse(), <item:create:golden_sheet>],
+  [<item:create:large_cogwheel>, <item:minecraft:clock>, <item:create:large_cogwheel>],
+  [<item:create:golden_sheet>, <item:create:sturdy_sheet>, <item:create:golden_sheet>]
+]);


### PR DESCRIPTION
This adds an alternative crafting recipe for the precision mechanism, one where a player won't have to do sequenced assembly if they do not want to. It uses mid-level create items, such as the deployer and sturdy sheet, and will still require to interact a little more in depth with the mod. There has also been a note added to the quest description to tell players this.

closes #792 