### PR TITLE
updates ftbquest mentions of evileye to clockworkeye

### DIFF
--- a/src/modlist.html
+++ b/src/modlist.html
@@ -2,7 +2,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/abnormals-delight">Abnormals Delight (by TeamAbnormals)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/advancement-plaques">Advancement Plaques [Neo/Forge] (by Grend_G)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/ageing-spawners">Ageing Spawners (by Mrbysco)</a></li>
-<li><a href="https://www.curseforge.com/minecraft/mc-mods/alexs-delight">Alex's Delight (by NCP_Bails)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/alexs-delight">Alex's Delight (by Baisylia)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/alexs-mobs">Alex's Mobs (by sbom_xela)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/alternate-current">Alternate Current (by SpaceWalkerRS)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/ambientsounds">AmbientSounds 6 (by CreativeMD)</a></li>
@@ -149,7 +149,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/fishing-dangers">Fishing Dangers (by DUCVN1882)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/fishing-minigame-for-1-19-2">Fishing Minigame(for latest ver) (by richestprune)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/fix-gpu-memory-leak">fix GPU memory leak[Forge/Fabric] (by someaddon)</a></li>
-<li><a href="https://www.curseforge.com/minecraft/mc-mods/friends-and-foes-forge">Friends&Foes (Forge/NeoForge) (Copper Golem,Crab,Glare,Moobloom,Iceologer,Rascal,Tuff Golem,Wildfire,Illusioner) (by Faboslav)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/friends-and-foes-forge">Friends&Foes (Forge/NeoForge) (Copper Golem,Glare,Crab,Moobloom,Iceologer,Rascal,Tuff Golem,Wildfire,Illusioner) (by Faboslav)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/ftb-chunks-forge">FTB Chunks (Forge) (by FTB)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/ftb-library-forge">FTB Library (Forge) (by FTB)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/ftb-quests-forge">FTB Quests (Forge) (by FTB)</a></li>

--- a/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
@@ -1463,7 +1463,7 @@
 				}
 				type: "item"
 			}]
-			title: "Polished Rose Quartz (Evil Eye)"
+			title: "Polished Rose Quartz (Clockwork Eye)"
 			x: 5.0d
 			y: 2.5d
 		}
@@ -1502,7 +1502,7 @@
 				}
 				type: "item"
 			}]
-			title: "Block of Experience (Evil Eye)"
+			title: "Block of Experience (Clockwork Eye)"
 			x: 3.0d
 			y: 2.5d
 		}
@@ -1657,7 +1657,7 @@
 				}
 				type: "item"
 			}]
-			title: "Precision Mechanism (Evil Eye)"
+			title: "Precision Mechanism (Clockwork Eye)"
 			x: 3.0d
 			y: -0.25d
 		}
@@ -1722,7 +1722,7 @@
 				}
 				type: "item"
 			}]
-			title: "Sturdy Sheet (Evil Eye)"
+			title: "Sturdy Sheet (Clockwork Eye)"
 			x: 5.0d
 			y: -0.25d
 		}
@@ -1762,7 +1762,7 @@
 				}
 				type: "item"
 			}]
-			title: "Brass Ingot (Evil Eye)"
+			title: "Brass Ingot (Clockwork Eye)"
 			x: 4.0d
 			y: -1.0d
 		}
@@ -1832,7 +1832,7 @@
 				}
 				type: "item"
 			}]
-			title: "Crushing Wheel (Evil Eye)"
+			title: "Crushing Wheel (Clockwork Eye)"
 			x: 6.25d
 			y: -1.0d
 		}
@@ -1889,7 +1889,7 @@
 				}
 				type: "item"
 			}]
-			title: "Mechanical Crafter (Evil Eye)"
+			title: "Mechanical Crafter (Clockwork Eye)"
 			x: 6.5d
 			y: -2.25d
 		}
@@ -1924,7 +1924,7 @@
 				}
 				type: "item"
 			}]
-			title: "Totem of Undying (Evil Eye)"
+			title: "Totem of Undying (Clockwork Eye)"
 			x: 2.5d
 			y: -3.25d
 		}
@@ -1978,7 +1978,7 @@
 					type: "item"
 				}
 			]
-			title: "Blaze Burner (Evil Eye)"
+			title: "Blaze Burner (Clockwork Eye)"
 			x: 3.0d
 			y: -2.0d
 		}
@@ -2010,7 +2010,7 @@
 				}
 				type: "item"
 			}]
-			title: "Netherrack (Evil Eye)"
+			title: "Netherrack (Clockwork Eye)"
 			x: 1.75d
 			y: -2.25d
 		}
@@ -3608,7 +3608,7 @@
 				}
 				type: "item"
 			}]
-			title: "Brass Hand (Evil Eye)"
+			title: "Brass Hand (Clockwork Eye)"
 			x: 4.0d
 			y: 3.25d
 		}


### PR DESCRIPTION
This update will change the mentions of evil eye to clockwork eye to match the correct eye name in ftbquests.

closes #753