### PR TITLE
remove create questing blueprint from inventory items tags

### DIFF
--- a/src/overrides/scripts/inventory-mod/gear_inventory_tags.zs
+++ b/src/overrides/scripts/inventory-mod/gear_inventory_tags.zs
@@ -477,7 +477,6 @@
 <tag:items:chocolate:gear>.add(<item:create:wand_of_symmetry>);
 <tag:items:chocolate:gear>.add(<item:create:wrench>);
 <tag:items:chocolate:gear>.add(<item:create_central_kitchen:cooking_guide>);
-<tag:items:chocolate:gear>.add(<item:create_questing:blueprint>);
 <tag:items:chocolate:gear>.add(<item:crittersandcompanions:gold_dragonfly_armor>);
 <tag:items:chocolate:gear>.add(<item:crittersandcompanions:iron_dragonfly_armor>);
 <tag:items:chocolate:gear>.add(<item:crittersandcompanions:pearl_necklace_1>);


### PR DESCRIPTION
create questing *should* only be a client side mod so its excluded from the server pack. butttt it has an item that was added to inventory mod tags. 

so we just remove it from the tags so server scripts dont break!