### PR TITLE
Questbook fixes

### DIFF
--- a/src/overrides/config/ftbquests/quests/chapters/53659F546FCEEC84.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/53659F546FCEEC84.snbt
@@ -622,7 +622,7 @@
 				"3AA58AD569CB791A"
 				"5B2AFAA309E25971"
 			]
-			description: ["on servers/lan, expert mode is actiavted for everyone once 1 player enters one of the envertwined dimensions."]
+			description: ["On servers/lan, expert mode is activated for everyone once one player defeats the Wither."]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -3002,7 +3002,7 @@
 		}
 		{
 			dependencies: ["3CF60CE0867D9A1A"]
-			description: ["neptunium gear can be found by fishing up neptune's bounties. these arte quite rare, but the item inside can be smelted down to an ingot, and the ingot can be used to upgrade diamond gear."]
+			description: ["Neptunium gear can be found by fishing up Neptune's Bounties. these arte quite rare, but the item inside can be smelted down to an ingot, and the ingot can be used to upgrade diamond gear."]
 			disable_toast: true
 			hide: false
 			icon: {

--- a/src/overrides/config/ftbquests/quests/chapters/53659F546FCEEC84.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/53659F546FCEEC84.snbt
@@ -115,7 +115,7 @@
 				""
 				"   You, for the first time in eons, have inspired hope in my people, thank you. Contiune on your adventure young one. Venture to the Everbright and Everdawn, summon ancient demons, and empower yourself with Netherite."
 				""
-				"    But becareful, long forgotten foes have started to rise...feeling the pull of the &lGods&r power. You have a long road ahead, I offer you another &eHeart&r as a sign of apperciation from my people. "
+				"    But be careful, long forgotten foes have started to rise...feeling the pull of the &lGods&r power. You have a long road ahead, I offer you another &eHeart&r as a sign of apperciation from my people. "
 			]
 			hide: true
 			icon: {
@@ -877,14 +877,14 @@
 		{
 			dependencies: ["45057A63E5057167"]
 			description: [
-				"to transfer enchantments:"
-				"1. right cloick the infusion table with a book"
-				"2. right click with the item you want to pull enchantments from"
-				"3. right click with flint and steel"
+				"To transfer enchantments:"
+				"1. Right click the infusion table with a book"
+				"2. Right click with the item you want to pull enchantments from"
+				"3. Right click with flint and steel"
 				""
 				"&l&oThe item will be destroyed&l&n"
 				""
-				"left click to pick up the enchanted book"
+				"Left click to pick up the enchanted book"
 			]
 			disable_toast: true
 			hide: false
@@ -909,7 +909,7 @@
 		}
 		{
 			dependencies: ["52CBD524A88A8E7E"]
-			description: ["abyssal quartz can be crafted or dropped by the mother of the maze in the ice maze (deep cold ocean)"]
+			description: ["Abyssal quartz can be crafted or dropped by the mother of the maze in the ice maze (deep cold ocean)"]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -1245,7 +1245,7 @@
 		}
 		{
 			dependencies: ["52CBD524A88A8E7E"]
-			description: ["increased armor and health but decreased damage and speed. you can be a true tank.. or more like a steel wall"]
+			description: ["Increased armor and health but decreased damage and speed. You can be a true tank.. or more like a steel wall"]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -1402,7 +1402,7 @@
 		}
 		{
 			dependencies: ["52CBD524A88A8E7E"]
-			description: ["overall good armor with some end-related set bonuses"]
+			description: ["Overall good armor with some end-related set bonuses"]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -1559,7 +1559,7 @@
 		}
 		{
 			dependencies: ["52CBD524A88A8E7E"]
-			description: ["provides less armour and reduces health, but increases damage. live your best glass cannon life"]
+			description: ["Provides less armour and reduces health, but increases damage. Live your best glass cannon life"]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -2709,7 +2709,7 @@
 		}
 		{
 			dependencies: ["7E7A9B546C15BE8A"]
-			description: ["the task list will always be accurate. the surrounding quests may be outdated* and are only here to provide more information."]
+			description: ["The task list will always be accurate. The surrounding quests may be outdated* and are only here to provide more information."]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -2768,7 +2768,7 @@
 		}
 		{
 			dependencies: ["318AC3A4B80FAB8E"]
-			description: ["the task list will always be accurate. the surrounding quests may be outdated* and are only here to provide more information."]
+			description: ["The task list will always be accurate. The surrounding quests may be outdated* and are only here to provide more information."]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -2842,7 +2842,7 @@
 		}
 		{
 			dependencies: ["33B00255BDE26589"]
-			description: ["the task list will always be accurate. the surrounding quests may be outdated* and are only here to provide more information."]
+			description: ["The task list will always be accurate. The surrounding quests may be outdated* and are only here to provide more information."]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -2884,7 +2884,7 @@
 		}
 		{
 			dependencies: ["51E899661EDC06BD"]
-			description: ["the task list will always be accurate. the surrounding quests may be outdated* and are only here to provide more information."]
+			description: ["The task list will always be accurate. The surrounding quests may be outdated* and are only here to provide more information."]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -2926,7 +2926,7 @@
 		}
 		{
 			dependencies: ["766544EE45C62981"]
-			description: ["the task list will always be accurate. the surrounding quests may be outdated* and are only here to provide more information."]
+			description: ["The task list will always be accurate. The surrounding quests may be outdated* and are only here to provide more information."]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -3002,7 +3002,11 @@
 		}
 		{
 			dependencies: ["3CF60CE0867D9A1A"]
-			description: ["Neptunium gear can be found by fishing up Neptune's Bounties. these arte quite rare, but the item inside can be smelted down to an ingot, and the ingot can be used to upgrade diamond gear."]
+			description: [
+				"Neptunium gear can be found by fishing up &eNeptune's Bounties&r. These are quite rare, but the item inside can be smelted down to an ingot, and the ingot can be used to upgrade diamond gear."
+				""
+				"Note that all forms of luck, as well as luck of the sea and lure, will increase the chance of getting a neptunium item. However, unusual catch will decrease the chance."
+				]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -3469,7 +3473,7 @@
 				"&3Weathering Tome (Prisnautilus)"
 				"&3Wave of Abyss (Prisnautilus)"
 				""
-				"these weapons arent necessarily any good, but damn do they look cool!"
+				"These weapons aren't necessarily any good, but damn do they look cool!"
 			]
 			disable_toast: true
 			hide: false
@@ -3583,19 +3587,19 @@
 		{
 			dependencies: ["3CF60CE0867D9A1A"]
 			description: [
-				"tetra scrolls for:"
+				"Tetra scrolls for:"
 				""
 				"- Mace head (single head)"
-				"- quarry hammer (hammer)"
-				"- compound string (bow string)"
-				"- key guard (sword)"
-				"- dreadnaught stave (bow staves)"
-				"- halberd head (single head)"
-				"- howling blade (sword)"
-				"- throwing knife (sword)"
-				"- sturdy guard (sword)"
+				"- Quarry hammer (hammer)"
+				"- Compound string (bow string)"
+				"- Key guard (sword)"
+				"- Dreadnaught stave (bow staves)"
+				"- Halberd head (single head)"
+				"- Howling blade (sword)"
+				"- Throwing knife (sword)"
+				"- Sturdy guard (sword)"
 				""
-				"place these down within a 5x5x5 area centered one block above a workbench to unlock new tool parts"
+				"Place these down within a 5x5x5 area centered one block above a workbench to unlock new tool parts"
 			]
 			disable_toast: true
 			hide: false
@@ -4262,12 +4266,12 @@
 		{
 			dependencies: ["4E676F48B6C7955B"]
 			description: [
-				"tetra scrolls for "
+				"Tetra scrolls for "
 				""
-				"- katana blade (sword)"
-				"- crucible blade (sword)"
-				"- flamberg blade (sword)"
-				"- rending scissors (sword)"
+				"- Katana blade (sword)"
+				"- Crucible blade (sword)"
+				"- Flamberg blade (sword)"
+				"- Rending scissors (sword)"
 			]
 			disable_toast: true
 			hide: false
@@ -4405,7 +4409,7 @@
 		{
 			dependencies: ["45057A63E5057167"]
 			description: [
-				"the murasama schematic is crafted as such"
+				"The murasama schematic is crafted as such"
 				""
 				"[              ,   sword  ,              ]"
 				""
@@ -4413,7 +4417,7 @@
 				"     ingot        quil         ingot"
 				"[             ,   sword   ,              ]"
 				""
-				"it provides a new blade option when upgrading a katana in a workbench"
+				"It provides a new blade option when upgrading a katana in a workbench"
 			]
 			disable_toast: true
 			hide: false

--- a/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
@@ -2101,6 +2101,8 @@
 				"This item can be obtained from &eNeptune's Bounty&r boxes, which are very rarely fished up. They can also be smelted down from Neptunium tools and armor, which are also found in &eNeptune's Bounty&r boxes."
 				""
 				"&eNeptunium Ingots&r craft the powerful Neptune gear, which have high affinity with water. They're locked to Stage One, however, so you need three of the Eyes to use them."
+				""
+				"Note that all forms of luck, as well as luck of the sea and lure, will increase the chance of getting a neptunium item. However, unusual catch will decrease the chance."
 			]
 			id: "0AF7A98BF910032D"
 			rewards: [

--- a/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
@@ -162,7 +162,7 @@
 			description: [
 				"This item can be crafted using a &eRed Mushroom&r, a &eBrown Mushroom&r, and &eGlowstone Dust&r&f."
 				""
-				"&eGlowstone Dust&r can be acquired from the Nether, structures, &cWitches&r, and crushing &ePrismarine Crystals&r. See the relevant quest for more!"
+				"&eGlowstone Dust&r can be acquired from the Nether, structures, &cWitches&r, and crushing &ePrismarine Crystals&r. It can also be crafted with ametrine shards, redstone, and various glowing ingredients. See the relevant quest for more!"
 			]
 			id: "1A8A4DEE5F184E8D"
 			rewards: [{
@@ -177,7 +177,7 @@
 				}
 				type: "item"
 			}]
-			subtitle: "Found in Glimmering Wealds or crafted"
+			subtitle: "Found in caves or crafted"
 			tasks: [{
 				id: "09AC1760CD2AC864"
 				item: {

--- a/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/easy_eyes.snbt
@@ -902,7 +902,7 @@
 			description: [
 				"This item is dropped by &4Sir Pumpkinhead&r, who can be summoned by breaking an &eInfernal Evil Pumpkin&r. You can locate these by just exploring your world, they'll have a ritual taking place with &eCandles&r all around it!"
 				""
-				"commonly found in vanilla plains and forest biomes, set your map to night mode and look for a small grouping of candles"
+				"They are commonly found in vanilla plains and forest biomes! At night, look on your map for a small grouping of candles"
 			]
 			id: "49171FCF7274350A"
 			rewards: [{

--- a/src/overrides/config/ftbquests/quests/chapters/hard_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/hard_eyes.snbt
@@ -2831,7 +2831,7 @@
 		{
 			dependencies: ["5DA4FF9594050625"]
 			description: [
-				"This item can be obtained by killing &cBlindsights&r that can be found in the Glowstone Canyon, Quartz Flats, or Infernal Dunes "
+				"This item can be obtained by killing &cBlindsights&r that can be found in the Glowstone Canyon"
 				""
 				""
 				"A &eBlindsight Tongue&r can also be used to craft a &eBlindsight Tongue Whip&r"

--- a/src/overrides/config/ftbquests/quests/chapters/medium_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/medium_eyes.snbt
@@ -175,7 +175,7 @@
 		{
 			dependencies: ["3901079844A43EC1"]
 			description: [
-				"This item can be obtained by killing a &cGlowsquito&r - which spawn in the Quartz Flats, Glowstone Canyon, and Infernal Dunes biomes"
+				"This item can be obtained by killing a &cGlowsquito&r - which spawn in the Glowstone Canyon biome"
 				""
 				"&eGlowcoke&r can also be used to craft &eGlowlight Torchs&r and &eGlowlight Campfires&r"
 			]

--- a/src/overrides/config/ftbquests/quests/chapters/optional_checklists.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/optional_checklists.snbt
@@ -3406,7 +3406,7 @@
 				}
 			}
 			id: "40CC9AECED3C9482"
-			subtitle: "Extremely Rare and Difficult Ash Barrens(Nether) Structure"
+			subtitle: "Extremely Rare and Difficult Nether Structure"
 			tasks: [{
 				id: "4C104B4A95B88589"
 				title: "Piglin Castle"
@@ -4274,7 +4274,7 @@
 				}
 			}
 			id: "63F9E8A0E9CC0996"
-			subtitle: "Rare and Very Difficult Quartz Flats Structure"
+			subtitle: "Rare and Very Difficult Nether Structure" 
 			tasks: [{
 				id: "0202885141731BFE"
 				title: "Sanctum"
@@ -4498,7 +4498,7 @@
 				}
 			}
 			id: "452B09FC0F95ADAC"
-			subtitle: "Rare Infernal Dunes Structure, that Spawns the Hovering Inferno with a Nether Star"
+			subtitle: "Rare Nether Structure, that Spawns the Hovering Inferno with a Nether Star"
 			tasks: [{
 				id: "11CCB8FF25FA0F16"
 				title: "Infernal Altar"

--- a/src/overrides/config/ftbquests/quests/chapters/optional_tips_and_tricks.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/optional_tips_and_tricks.snbt
@@ -263,7 +263,7 @@
 			id: "68A051FE5006E6C1"
 			shape: "gear"
 			size: 1.5d
-			subtitle: "Difficulty Scales in this pack, in that once you enter the Everbright/Everdawn you are put into expert mode. Expert:hundreds of new mobs spawn all over the world, mobs slightly more likely to spawn buffed. Undead Army has two new waves, one with a Tank, the other with Cerberus. All bonuses also increase experience and loot gained from mobs."
+			subtitle: "Difficulty scales in this pack, in that once you defeat the Wither you are put into expert mode. Expert:hundreds of new mobs spawn all over the world, mobs slightly more likely to spawn buffed. Undead Army has two new waves, one with a Tank, the other with Cerberus. All bonuses also increase experience and loot gained from mobs."
 			tasks: [{
 				id: "5822C2F673DC9354"
 				title: "Difficulty Scaling"

--- a/src/overrides/config/ftbquests/quests/chapters/quests.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/quests.snbt
@@ -6217,17 +6217,6 @@
 					}
 					type: "item"
 				}
-				{
-					id: "29FF2022DD2CC3D8"
-					item: {
-						Count: 1b
-						ForgeCaps: {
-							"dungeons_libraries:built_in_enchantments": { }
-						}
-						id: "enlightened_end:glacium"
-					}
-					type: "item"
-				}
 			]
 			title: "Master Metalworker"
 			x: -7.5d

--- a/src/overrides/config/ftbquests/quests/chapters/tips_and_tricks.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/tips_and_tricks.snbt
@@ -539,7 +539,7 @@
 			y: -18.5d
 		}
 		{
-			description: ["Expert mode is activated for all players once one person first visits the Everbright or Everdawn. It includes many new difficult mob spawns."]
+			description: ["Expert mode is activated for all players once one person first defeats the Wither. It includes many new difficult mob spawns."]
 			disable_toast: true
 			icon: {
 				Count: 1b

--- a/src/overrides/scripts/recipes/misc/storagedrawers.zs
+++ b/src/overrides/scripts/recipes/misc/storagedrawers.zs
@@ -1,0 +1,4 @@
+craftingTable.addShaped("conversion_upgrade",<item:storagedrawers:conversion_upgrade>, 
+[[<item:minecraft:lapis_lazuli>,<tag:items:balm:wooden_rods>,<item:minecraft:lapis_lazuli>],
+[<tag:items:balm:wooden_rods>,<item:storagedrawers:upgrade_template>,<tag:items:balm:wooden_rods>],
+[<item:minecraft:lapis_lazuli>,<tag:items:balm:wooden_rods>,<item:minecraft:lapis_lazuli>]]);


### PR DESCRIPTION
Fixes various small issues within the Questbook.

Closes #891 Removes glacium from the Master Metalworker quest, as glacium was not obtainable
Closes #866 Fixes mention of 'night mode' for new map mod
Closes #878 Changes Expert Mode information given in a couple of quests, to say that it is activated by defeating the Wither
Closes #854 Adds a note to a couple of Neptune's Bounty quests to specify which luck effects change the chances
Closes #798 Removes mention of three of Incendium's biomes in a few different quests
Closes #773 Fixes the Lost Eye glow shroom quest to mention how to craft glowstone and remove a reference to Glimmering Wealds
Closes #756 Storage drawer conversion upgrade had no crafting recipe; one was added in the misc folder for crafttweaker to match other recipes
In addition capitalized a few sentences in quest descriptions