### PR TITLE
remove worthless and disabled enchants

### DIFF
--- a/src/overrides/config/quark-common.toml
+++ b/src/overrides/config/quark-common.toml
@@ -1712,7 +1712,7 @@
 		"Disable Offset" = false
 
 	[experimental.enchantments_begone]
-		"Enchantments To Begone" = ["unusualend:everlasting"]
+		"Enchantments To Begone" = ["unusualend:everlasting","epicsamurai:demon_slayer"]
 
 	[experimental.game_nerfs]
 		#Makes Mending act like the Unmending mod
@@ -1858,7 +1858,7 @@
 		#Candles with soul sand below them or below the bookshelves dampen enchantments instead of influence them.
 		"Soul Candles Invert" = true
 		#A list of enchantment IDs you don't want the enchantment table to be able to create
-		"Disallowed Enchantments" = ["unusualend:everlasting", "combatroll:acrobat", "combatroll:longfooted", "combatroll:multi_roll", "create:potato_recovery", "create:capacity", "minecraft:mending"]
+		"Disallowed Enchantments" = ["unusualend:everlasting", "epicsamurai:demon_slayer", "combatroll:acrobat", "combatroll:longfooted", "combatroll:multi_roll", "create:potato_recovery", "create:capacity", "minecraft:mending"]
 		#An array of influences each candle should apply. This list must be 16 elements long, and is in order of wool colors.
 		#A minus sign before an enchantment will make the influence decrease the probability of that enchantment.
 		"Influences List" = ["minecraft:unbreaking", "minecraft:fire_protection,enigmaticlegacy:torrent,alexsmobs:lavawax", "minecraft:knockback,minecraft:punch,unusualend:boloks_fury,farmersdelight:backstabbing,enigmaticlegacy:sharpshooter,alexsmobs:straddle_jump", "minecraft:feather_falling", "minecraft:looting,minecraft:fortune,minecraft:luck_of_the_sea", "minecraft:blast_protection", "minecraft:silk_touch,minecraft:channeling", "minecraft:bane_of_arthropods", "minecraft:protection,alexsmobs:serpentfriend", "minecraft:respiration,minecraft:loyalty,minecraft:infinity,alexsmobs:board_return,enigmaticlegacy:ceaseless", "minecraft:sweeping,minecraft:multishot", "minecraft:efficiency,minecraft:sharpness,minecraft:lure,minecraft:power,minecraft:impaling,minecraft:quick_charge", "minecraft:aqua_affinity,minecraft:depth_strider,minecraft:riptide,unusualfishmod:unusual_catch", "minecraft:thorns,minecraft:piercing", "minecraft:fire_aspect,minecraft:flame", "minecraft:smite,minecraft:projectile_protection"]

--- a/src/overrides/config/quark-common.toml
+++ b/src/overrides/config/quark-common.toml
@@ -1712,7 +1712,7 @@
 		"Disable Offset" = false
 
 	[experimental.enchantments_begone]
-		"Enchantments To Begone" = ["unusualend:everlasting","epicsamurai:demon_slayer"]
+		"Enchantments To Begone" = ["unusualend:everlasting", "epicsamurai:demon_slayer", "enigmaticlegacy:wrath", "enigmaticlegacy:slayer"]
 
 	[experimental.game_nerfs]
 		#Makes Mending act like the Unmending mod
@@ -1858,7 +1858,7 @@
 		#Candles with soul sand below them or below the bookshelves dampen enchantments instead of influence them.
 		"Soul Candles Invert" = true
 		#A list of enchantment IDs you don't want the enchantment table to be able to create
-		"Disallowed Enchantments" = ["unusualend:everlasting", "epicsamurai:demon_slayer", "combatroll:acrobat", "combatroll:longfooted", "combatroll:multi_roll", "create:potato_recovery", "create:capacity", "minecraft:mending"]
+		"Disallowed Enchantments" = ["unusualend:everlasting", "epicsamurai:demon_slayer","enigmaticlegacy:wrath", "enigmaticlegacy:slayer", "combatroll:acrobat", "combatroll:longfooted", "combatroll:multi_roll", "create:potato_recovery", "create:capacity", "minecraft:mending"]
 		#An array of influences each candle should apply. This list must be 16 elements long, and is in order of wool colors.
 		#A minus sign before an enchantment will make the influence decrease the probability of that enchantment.
 		"Influences List" = ["minecraft:unbreaking", "minecraft:fire_protection,enigmaticlegacy:torrent,alexsmobs:lavawax", "minecraft:knockback,minecraft:punch,unusualend:boloks_fury,farmersdelight:backstabbing,enigmaticlegacy:sharpshooter,alexsmobs:straddle_jump", "minecraft:feather_falling", "minecraft:looting,minecraft:fortune,minecraft:luck_of_the_sea", "minecraft:blast_protection", "minecraft:silk_touch,minecraft:channeling", "minecraft:bane_of_arthropods", "minecraft:protection,alexsmobs:serpentfriend", "minecraft:respiration,minecraft:loyalty,minecraft:infinity,alexsmobs:board_return,enigmaticlegacy:ceaseless", "minecraft:sweeping,minecraft:multishot", "minecraft:efficiency,minecraft:sharpness,minecraft:lure,minecraft:power,minecraft:impaling,minecraft:quick_charge", "minecraft:aqua_affinity,minecraft:depth_strider,minecraft:riptide,unusualfishmod:unusual_catch", "minecraft:thorns,minecraft:piercing", "minecraft:fire_aspect,minecraft:flame", "minecraft:smite,minecraft:projectile_protection"]


### PR DESCRIPTION
enchantment begone documentation says it removes from loot pools+villager pools so freedom from the wrath/slayer questions too closes #899, #544 