### PR TITLE
fix expert mode trigger and unblock progression related mobs

### DIFF
--- a/src/overrides/config/ftbquests/quests/chapters/53659F546FCEEC84.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/53659F546FCEEC84.snbt
@@ -618,10 +618,7 @@
 			y: -14.25d
 		}
 		{
-			dependencies: [
-				"3AA58AD569CB791A"
-				"5B2AFAA309E25971"
-			]
+			dependencies: ["15F2D8BAFA731EBC"]
 			description: ["On servers/lan, expert mode is activated for everyone once one player defeats the Wither."]
 			disable_toast: true
 			hide: false
@@ -633,15 +630,15 @@
 				}
 			}
 			id: "3FFC286F3D0CF299"
-			subtitle: "Unlocked by going to the Everbright or Everdawn, which release the spirits of Light and Dark. Spawns hundreds of new, unique mobs all over the world. The new mobs are REALLY tough.."
+			subtitle: "Unlocked by defeating the wither, which release the spirits of Light and Dark. Spawns hundreds of new, unique mobs all over the world. The new mobs can be pretty tough, make sure you are prepared!"
 			tasks: [{
 				disable_toast: true
 				id: "3DE4000CD51C8B52"
 				title: "Expert Mode"
 				type: "checkmark"
 			}]
-			x: 2.25d
-			y: -19.5d
+			x: 9.25d
+			y: -14.5d
 		}
 		{
 			dependencies: ["45057A63E5057167"]
@@ -3006,7 +3003,7 @@
 				"Neptunium gear can be found by fishing up &eNeptune's Bounties&r. These are quite rare, but the item inside can be smelted down to an ingot, and the ingot can be used to upgrade diamond gear."
 				""
 				"Note that all forms of luck, as well as luck of the sea and lure, will increase the chance of getting a neptunium item. However, unusual catch will decrease the chance."
-				]
+			]
 			disable_toast: true
 			hide: false
 			icon: {

--- a/src/overrides/config/ftbquests/quests/chapters/tips_and_tricks.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/tips_and_tricks.snbt
@@ -541,13 +541,7 @@
 		{
 			description: ["Expert mode is activated for all players once one person first defeats the Wither. It includes many new difficult mob spawns."]
 			disable_toast: true
-			icon: {
-				Count: 1b
-				ForgeCaps: {
-					"dungeons_libraries:built_in_enchantments": { }
-				}
-				id: "blue_skies:everdawn_portal"
-			}
+			icon: "majruszsdifficulty:wither_treasure_bag"
 			id: "259849F8F8F13A0A"
 			size: 2.0d
 			tasks: [{

--- a/src/overrides/config/majruszsdifficulty.json
+++ b/src/overrides/config/majruszsdifficulty.json
@@ -20,9 +20,7 @@
           "BOLD"
         ],
         "triggers": {
-          "dimensions": [
-            "{regex}.*"
-          ],
+          "dimensions": [],
           "entities": [
             "minecraft:wither"
           ]
@@ -398,10 +396,6 @@
           "aquamirae:maze_mother",
           "born_in_chaos_v1:glutton_fish",
           "graveyard:ghouling",
-          "mutantmonsters:mutant_creeper",
-          "mutantmonsters:mutant_zombie",
-          "mutantmonsters:mutant_enderman",
-          "mutantmonsters:mutant_skeleton",
           "born_in_chaos_v1:infernal_spirit",
           "iter_rpg:hobgoblin",
           "iter_rpg:goblin",
@@ -416,14 +410,10 @@
           "mutantmonsters:spider_pig",
           "cataclysm:the_prowler",
           "cataclysm:the_watcher",
-          "cataclysm:coral_golem",
           "cataclysm:deepling_angler",
           "cataclysm:deepling_brute",
-          "cataclysm:deepling_priest",
-          "cataclysm:deepling_warlock",
           "cataclysm:lionfish",
           "dungeons_mobs:wavewhisperer",
-          "cataclysm:coralssus",
           "cataclysm:kobolediator",
           "cataclysm:koboleton",
           "cataclysm:wadjet",


### PR DESCRIPTION
closes #893 
closes #876 
closes #880 

- fix expert mode activating from entering the nether
- allow mutant zombie, skele, creeper and enderman to spawn in normal mode 
- allow corallsus, coral golem, deepling priest and warlock to spawn in normal mode
- fix questbook entries regarding expert mode