### PR TITLE
update cataclysm 2.25 -> 2.46

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1010,7 +1010,7 @@
       "required": true
     },
     {
-      "fileID": 5921717,
+      "fileID": 6470672,
       "projectID": 551586,
       "required": true
     },
@@ -1837,11 +1837,6 @@
     {
       "fileID": 5529866,
       "projectID": 1063296,
-      "required": true
-    },
-    {
-      "fileID": 5557456,
-      "projectID": 1069500,
       "required": true
     },
     {

--- a/src/modlist.html
+++ b/src/modlist.html
@@ -1,4 +1,4 @@
-﻿<ul>
+<ul>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/abnormals-delight">Abnormals Delight (by TeamAbnormals)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/advancement-plaques">Advancement Plaques [Neo/Forge] (by Grend_G)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/ageing-spawners">Ageing Spawners (by Mrbysco)</a></li>
@@ -11,7 +11,6 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/appleskin">AppleSkin (by squeek502)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/aquaculture">Aquaculture 2 (by Shadow)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/aquaculture-delight">Aquaculture Delight (A Farmer's Delight Add-on) (by nocubeyt)</a></li>
-<li><a href="https://www.curseforge.com/minecraft/mc-mods/archeology-api">Archeology API (by min01)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/architectury-api">Architectury API (by shedaniel)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/armor-adjustment">Armor Adjustment (by PerpetualEve)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/art-of-forging-a-tetra-addon">Art of Forging: A Tetra Addon (by Ace_The_Eldritch_King)</a></li>

--- a/src/overrides/config/cataclysm.toml
+++ b/src/overrides/config/cataclysm.toml
@@ -48,9 +48,6 @@
 	#Void Core's Cooldown
 	#Range: 0 ~ 1000000
 	VoidCoreCooldown = 160
-	#Sandstorm's Timer
-	#Range: 0 ~ 1000000
-	SandstormTimer = 160
 	#Soul Render's Timer
 	#Range: 0 ~ 1000000
 	SoulRenderCooldown = 100
@@ -60,6 +57,9 @@
 	#The Immolator's Timer
 	#Range: 0 ~ 1000000
 	immolatorCooldown = 300
+	#Sandstorm's cooldown
+	#Range: 0 ~ 1000000
+	Sandstormcooldown = 300
 
 [Block]
 	#Cursed Tombstone Summon cooldown Minute
@@ -127,6 +127,12 @@
 	#Cursed Sandstorm's Damage
 	#Range: 0.0 ~ 1000000.0
 	"Cursed Sandstorm Damage" = 6.0
+	#Flame jet's Damage
+	#Range: 0.0 ~ 1000000.0
+	"Flame Jet Damage" = 7.0
+	#Flare Bomb's Damage
+	#Range: 0.0 ~ 1000000.0
+	"Flare Bomb Damage" = 7.0
 
 ["Ender Guardian"]
 	#EnderGuardian's Health Multiplier
@@ -204,6 +210,8 @@
 	#Monstrosity's Immune to Long distance attack range.
 	#Range: 1.0 ~ 1000000.0
 	"Monstrosity's prevent attacks from far away Range" = 18.0
+	#Monstrosity's block breaking ignore the MobGriefing
+	monstrosityBlockBreaking = true
 
 ["Ender Golem"]
 	#Ender Golem's block breaking ignore the MobGriefing
@@ -515,4 +523,9 @@
 	#Allowed height variance for the check - if the variance is lower than this value the structure will not spawn (has no effect if the are check is disabled)
 	#Range: 0 ~ 32
 	cursedPyramidHeightVariance = 7
+
+["Netherite Ministrosity"]
+	#Ministrosity's Health Multiplier
+	#Range: 0.0 ~ 1000000.0
+	MinistrosityHealthMultiplier = 1.0
 

--- a/src/overrides/config/everycomp-wood_types.toml
+++ b/src/overrides/config/everycomp-wood_types.toml
@@ -162,6 +162,9 @@
 			chorus = true
 			frosted_stone_brick = true
 			stone_tile = true
+			azure_seastone = true
+			azure_seastone_brick = true
+			polished_azure_seastone = true
 
 		[types.cut_block_type.nourished_nether]
 			netherrack = true

--- a/src/overrides/config/ftbquests/quests/chapters/53659F546FCEEC84.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/53659F546FCEEC84.snbt
@@ -871,7 +871,7 @@
 				}
 			]
 			title: "Dark Metal Gear and other weapons"
-			x: -5.5d
+			x: -5.0d
 			y: -23.0d
 		}
 		{
@@ -905,7 +905,7 @@
 			}]
 			title: "Disenchanting"
 			x: -6.25d
-			y: -22.0d
+			y: -22.25d
 		}
 		{
 			dependencies: ["52CBD524A88A8E7E"]
@@ -1772,10 +1772,43 @@
 					}
 					type: "item"
 				}
+				{
+					id: "0B6424AE585FE72F"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:gauntlet_of_maelstrom"
+					}
+					type: "item"
+				}
+				{
+					id: "4E55BD45D165373B"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:the_immolator"
+					}
+					type: "item"
+				}
+				{
+					id: "7DBC56E821C9A15B"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:wrath_of_the_desert"
+					}
+					type: "item"
+				}
 			]
 			title: "Godlike Unbreakable Boss Weapons"
-			x: -13.5d
-			y: -6.25d
+			x: -14.75d
+			y: -7.0d
 		}
 		{
 			dependencies: ["033E7215F1636702"]
@@ -1822,8 +1855,8 @@
 				}
 			]
 			title: "Advanced Elytra"
-			x: -13.0d
-			y: -8.75d
+			x: -12.25d
+			y: -9.25d
 		}
 		{
 			dependencies: ["033E7215F1636702"]
@@ -1930,8 +1963,8 @@
 				}
 			]
 			title: "Ignitium Gear"
-			x: -14.0d
-			y: -8.25d
+			x: -13.75d
+			y: -9.25d
 		}
 		{
 			dependencies: ["033E7215F1636702"]
@@ -1981,8 +2014,8 @@
 				}
 			]
 			title: "Witherite weapons"
-			x: -14.25d
-			y: -7.25d
+			x: -14.5d
+			y: -8.25d
 		}
 		{
 			dependencies: ["766544EE45C62981"]
@@ -2008,8 +2041,8 @@
 				}
 				type: "item"
 			}]
-			x: -15.25d
-			y: -5.25d
+			x: -14.5d
+			y: -3.25d
 		}
 		{
 			dependencies: ["581D0DDCE25134AA"]
@@ -2026,8 +2059,8 @@
 				type: "checkmark"
 			}]
 			title: "Something 1,000,000 blocks out"
-			x: -18.375d
-			y: -3.75d
+			x: -17.625d
+			y: -1.5d
 		}
 		{
 			dependencies: ["033E7215F1636702"]
@@ -2137,8 +2170,8 @@
 				}
 			]
 			title: "celestial weapons"
-			x: -11.75d
-			y: -8.25d
+			x: -11.5d
+			y: -8.0d
 		}
 		{
 			dependencies: ["4E676F48B6C7955B"]
@@ -2271,8 +2304,8 @@
 					type: "item"
 				}
 			]
-			x: -4.25d
-			y: -23.0d
+			x: -3.75d
+			y: -22.25d
 		}
 		{
 			dependencies: ["52CBD524A88A8E7E"]
@@ -2963,8 +2996,8 @@
 				}
 			]
 			title: "Stage Five Items"
-			x: -12.5d
-			y: -7.25d
+			x: -12.75d
+			y: -6.75d
 		}
 		{
 			dependencies: ["51E899661EDC06BD"]
@@ -2997,8 +3030,8 @@
 				title: "The Nexus"
 				type: "dimension"
 			}]
-			x: -12.25d
-			y: -4.75d
+			x: -11.5d
+			y: -4.25d
 		}
 		{
 			dependencies: ["3CF60CE0867D9A1A"]
@@ -3006,7 +3039,7 @@
 				"Neptunium gear can be found by fishing up &eNeptune's Bounties&r. These are quite rare, but the item inside can be smelted down to an ingot, and the ingot can be used to upgrade diamond gear."
 				""
 				"Note that all forms of luck, as well as luck of the sea and lure, will increase the chance of getting a neptunium item. However, unusual catch will decrease the chance."
-				]
+			]
 			disable_toast: true
 			hide: false
 			icon: {
@@ -4454,8 +4487,8 @@
 				type: "item"
 			}]
 			title: "Murasama Blade"
-			x: -3.25d
-			y: -21.75d
+			x: -4.0d
+			y: -21.0d
 		}
 		{
 			dependencies: ["52CBD524A88A8E7E"]
@@ -4547,6 +4580,108 @@
 			title: "Lich's bone staffs"
 			x: -12.75d
 			y: -16.5d
+		}
+		{
+			dependencies: ["45057A63E5057167"]
+			description: ["Gear crafted from cursium, a metal you get from defeating maledictus"]
+			disable_toast: true
+			hide: false
+			icon: "cataclysm:the_annihilator"
+			id: "06D153CC931C76DE"
+			tasks: [
+				{
+					id: "734B8886E6897429"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:cursium_helmet"
+						tag: {
+							Damage: 0
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "7E5946EC5BC3A3D2"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:cursium_chestplate"
+						tag: {
+							Damage: 0
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "657A5CB1D2E15DAC"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:cursium_leggings"
+						tag: {
+							Damage: 0
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "11DA2386AE03DD3E"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:cursium_boots"
+						tag: {
+							Damage: 0
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "1AA7F1A1248BF6FC"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:cursed_bow"
+					}
+					type: "item"
+				}
+				{
+					id: "42598A7A64713735"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:the_annihilator"
+					}
+					type: "item"
+				}
+				{
+					id: "6DC856F4F15F7625"
+					item: {
+						Count: 1b
+						ForgeCaps: {
+							"dungeons_libraries:built_in_enchantments": { }
+						}
+						id: "cataclysm:soul_render"
+					}
+					type: "item"
+				}
+			]
+			title: "Cursium Gear"
+			x: -6.25d
+			y: -20.75d
 		}
 	]
 	title: "&4Entries"

--- a/src/overrides/scripts/createstages.zs
+++ b/src/overrides/scripts/createstages.zs
@@ -176,6 +176,9 @@ var itemsStageTwo = [
 	<item:born_in_chaos_v1:nightmare_mantleofthe_night_leggings>,
 	<item:born_in_chaos_v1:nightmare_mantleofthe_night_chestplate>,
 	<item:born_in_chaos_v1:nightmare_mantleofthe_night_helmet>,
+	<item:cataclysm:ancient_spear>,
+	<item:cataclysm:bone_reptile_helmet>,
+	<item:cataclysm:bone_reptile_chestplate>,
 
 	//--//---------------------------------------------------- BACKPACK --------------------------------------------------------------//--//
 	<item:sophisticatedbackpacks:gold_backpack>,
@@ -212,6 +215,13 @@ var itemsStageThree = [
 	<item:born_in_chaos_v1:skullbreaker_hammer>,
 	<item:born_in_chaos_v1:trident_hayfork>,
 	<item:born_in_chaos_v1:dark_ritual_dagger>,
+	<item:cataclysm:soul_render>,
+	<item:cataclysm:cursium_helmet>,
+	<item:cataclysm:cursium_chestplate>,
+	<item:cataclysm:cursium_leggings>,
+	<item:cataclysm:cursium_boots>,
+  <item:cataclysm:the_annihilator>,
+	<item:cataclysm:cursed_bow>,
 	//--//---------------------------------------------------- BACKPACK --------------------------------------------------------------//--//
 	<item:sophisticatedbackpacks:diamond_backpack>,
 	<item:sophisticatedbackpacks:feeding_upgrade>,
@@ -316,7 +326,10 @@ var itemsStageFive = [
 	<item:celestisynth:aquaflora>,
 	<item:celestisynth:poltergeist>,
 	<item:celestisynth:breezebreaker>,
-	<item:alexsmobs:dimensional_carver>
+	<item:alexsmobs:dimensional_carver>,
+	<item:cataclysm:the_immolator>,
+	<item:cataclysm:wrath_of_the_desert>,
+	<item:cataclysm:gauntlet_of_maelstrom>
 ];
 
 // --------------------------------------------------- CURSED (DISABLED) ITEMS ------------------------------------------------------------------//


### PR DESCRIPTION
closes #743 
closes #914 

removes archeology api which was removed from CF

gated new items (maledictus cursium items and others)

changelog:
- downgrade Lionfish api
- Fixed Gauntlet of maelstorm's void vortex pull the caster
- Nerfed Guantlet of maelstorm's cooldown and duration
- Fixed the position of the Wide player model for blazing grips and sticky gloves
- Blazing grips and sticky gloves now have visible first-person models
- Added New blocks for future plans
- Updated Netherite Monstrosity Changed sandstorm bottle
- Fixed Grab attack multi bug
- Added Perfect guard in bulwark of flame
- Increased N.M's step height
- Increased N.M's Head bonus Damage (1.35->1.8)
- Fixed Soul black Smith (pillar lava)
- Buffed Void Forge and Infernal Forge
- Fixed Ministrosity's loot table
- Increased N.M's Magma bomb Cooldown
- Reduced N.M's Flare Bomb Cooldown
- Changed Maledictus,Kobolediator,Remnant,Aptr's Rendering
- Added Blocks For future
- Nerfed N.M's Rush start delay
- Updated fusion anvil and ministrosity's GUI
- Changed Ministrosity's inventory code
- Maybe Fixed Ministrosity inventory Packet
- Really Fixed Ministrosity packet
- Fixed new block model
- Changed Creative Tab Added Blazing Grips Layer
- Maybe Fixed Leviathan's tongue
- Now Leviathan is not affected by the bubble column
- Added Blocks
- Fixed a bug where certain entities would take fall damage
- Changed Bolt Strike sound(W.I.P)
- Changed Cursium armor Model
- Updated Death Laser's Visual
- Fixed Cursium Armor
- Fixed Falling block renderer cause crash
- Archaeology API included.