### PR TITLE
wildfire drops

### DIFF
--- a/src/overrides/config/paxi/datapacks/chocmobs/data/dungeons_mobs/loot_tables/entities/wildfire.json
+++ b/src/overrides/config/paxi/datapacks/chocmobs/data/dungeons_mobs/loot_tables/entities/wildfire.json
@@ -1,0 +1,25 @@
+{
+	"type": "minecraft:entity",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"functions": [
+						{
+							"function": "minecraft:set_count",
+							"count": {
+								"type": "minecraft:uniform",
+								"min": 5.0,
+								"max": 5.0
+							},
+							"add": false
+						}
+					],
+					"name": "friendsandfoes:wildfire_crown_fragment"
+				}
+			]
+		}
+	]
+}

--- a/src/overrides/config/paxi/datapacks/chocmobs/data/friendsandfoes/loot_tables/entities/wildfire.json
+++ b/src/overrides/config/paxi/datapacks/chocmobs/data/friendsandfoes/loot_tables/entities/wildfire.json
@@ -1,0 +1,25 @@
+{
+	"type": "minecraft:entity",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"functions": [
+						{
+							"function": "minecraft:set_count",
+							"count": {
+								"type": "minecraft:uniform",
+								"min": 5.0,
+								"max": 10.0
+							},
+							"add": false
+						}
+					],
+					"name": "friendsandfoes:wildfire_crown_fragment"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
does a little bit of #911 those dungeonsmobs mobs probably need a better solution imo.

the drops for the armor/weapons aren't in the data part of the mod and don't really want to add more unstackables to raid mobs. think all the bad rng drop mobs mentioned there but drowned necro are in some raid