### PR TITLE
allow loading mpuc "incompatible world"

### DIFF
--- a/src/overrides/config/modpack-update-checker/config.json
+++ b/src/overrides/config/modpack-update-checker/config.json
@@ -6,6 +6,7 @@
   "modpackReleaseType": "stable",
   "updateCheckerId": "https://raw.githubusercontent.com/chocolate-edition/Chocolate-Edition/refs/heads/main/modpackUpdateChecker/",
   "advanced": {
+    "forceModpackCompatible": true,
     "bccEnabled": false,
     "expandButton": true,
     "updateCheckerType": 2,


### PR DESCRIPTION
closes #936 
this change allows you to proceed past "incompatible world"

kinda late now but will ensure we have no other issues in the future
![image](https://github.com/user-attachments/assets/54f860b8-96c8-4aa8-9982-4d152598fb68)

![image](https://github.com/user-attachments/assets/ec09260b-6b75-4ced-9a66-cdef05f11c80)
