### PR TITLE
remove hellstrider

### DIFF
--- a/src/overrides/config/quark-common.toml
+++ b/src/overrides/config/quark-common.toml
@@ -754,7 +754,7 @@
 		"Item Quality" = 2
 		"Normal Upgrade Cost" = 10
 		"Limit Break Upgrade Cost" = 30
-		"Valid Enchantments" = ["minecraft:feather_falling", "minecraft:thorns", "minecraft:sharpness", "minecraft:smite", "minecraft:bane_of_arthropods", "minecraft:knockback", "minecraft:fire_aspect", "minecraft:looting", "minecraft:sweeping", "minecraft:efficiency", "minecraft:unbreaking", "minecraft:fortune", "minecraft:power", "minecraft:punch", "minecraft:luck_of_the_sea", "minecraft:lure", "minecraft:loyalty", "minecraft:riptide", "minecraft:impaling", "minecraft:piercing", "minecraft:quick_charge", "minecraft:swift_sneak", "minecraft:soul_speed", "minecraft:frost_walker", "minecraft:protection", "minecraft:projectile_protection", "minecraft:fire_protection", "minecraft:blast_protection", "unusualend:boloks_fury", "netherdepthsupgrade:hell_strider", "farmersdelight:backstabbing", "enigmaticlegacy:torrent", "enigmaticlegacy:sharpshooter", "alexsmobs:straddle_jump", "combatroll:acrobat", "combatroll:longfooted", "combatroll:multi_roll", "create:capacity", "create:potato_recovery"]
+		"Valid Enchantments" = ["minecraft:feather_falling", "minecraft:thorns", "minecraft:sharpness", "minecraft:smite", "minecraft:bane_of_arthropods", "minecraft:knockback", "minecraft:fire_aspect", "minecraft:looting", "minecraft:sweeping", "minecraft:efficiency", "minecraft:unbreaking", "minecraft:fortune", "minecraft:power", "minecraft:punch", "minecraft:luck_of_the_sea", "minecraft:lure", "minecraft:loyalty", "minecraft:riptide", "minecraft:impaling", "minecraft:piercing", "minecraft:quick_charge", "minecraft:swift_sneak", "minecraft:soul_speed", "minecraft:frost_walker", "minecraft:protection", "minecraft:projectile_protection", "minecraft:fire_protection", "minecraft:blast_protection", "unusualend:boloks_fury", "farmersdelight:backstabbing", "enigmaticlegacy:torrent", "enigmaticlegacy:sharpshooter", "alexsmobs:straddle_jump", "combatroll:acrobat", "combatroll:longfooted", "combatroll:multi_roll", "create:capacity", "create:potato_recovery"]
 		"Overleveled Books Glow Rainbow" = true
 		#When enabled, Efficiency VI Diamond and Netherite pickaxes can instamine Deepslate when under Haste 2
 		"Deepslate Tweak" = true
@@ -1712,7 +1712,7 @@
 		"Disable Offset" = false
 
 	[experimental.enchantments_begone]
-		"Enchantments To Begone" = ["unusualend:everlasting", "epicsamurai:demon_slayer", "enigmaticlegacy:wrath", "enigmaticlegacy:slayer"]
+		"Enchantments To Begone" = ["unusualend:everlasting", "epicsamurai:demon_slayer", "enigmaticlegacy:wrath", "enigmaticlegacy:slayer", "netherdepthsupgrade:hell_strider"]
 
 	[experimental.game_nerfs]
 		#Makes Mending act like the Unmending mod
@@ -1858,7 +1858,7 @@
 		#Candles with soul sand below them or below the bookshelves dampen enchantments instead of influence them.
 		"Soul Candles Invert" = true
 		#A list of enchantment IDs you don't want the enchantment table to be able to create
-		"Disallowed Enchantments" = ["unusualend:everlasting", "epicsamurai:demon_slayer", "enigmaticlegacy:wrath", "enigmaticlegacy:slayer", "combatroll:acrobat", "combatroll:longfooted", "combatroll:multi_roll", "create:potato_recovery", "create:capacity", "minecraft:mending"]
+		"Disallowed Enchantments" = ["unusualend:everlasting", "epicsamurai:demon_slayer", "enigmaticlegacy:wrath", "enigmaticlegacy:slayer", "combatroll:acrobat", "combatroll:longfooted", "combatroll:multi_roll", "create:potato_recovery", "create:capacity", "minecraft:mending", "netherdepthsupgrade:hell_strider"]
 		#An array of influences each candle should apply. This list must be 16 elements long, and is in order of wool colors.
 		#A minus sign before an enchantment will make the influence decrease the probability of that enchantment.
 		"Influences List" = ["minecraft:unbreaking", "minecraft:fire_protection,enigmaticlegacy:torrent,alexsmobs:lavawax", "minecraft:knockback,minecraft:punch,unusualend:boloks_fury,farmersdelight:backstabbing,enigmaticlegacy:sharpshooter,alexsmobs:straddle_jump", "minecraft:feather_falling", "minecraft:looting,minecraft:fortune,minecraft:luck_of_the_sea", "minecraft:blast_protection", "minecraft:silk_touch,minecraft:channeling", "minecraft:bane_of_arthropods", "minecraft:protection,alexsmobs:serpentfriend", "minecraft:respiration,minecraft:loyalty,minecraft:infinity,alexsmobs:board_return,enigmaticlegacy:ceaseless", "minecraft:sweeping,minecraft:multishot", "minecraft:efficiency,minecraft:sharpness,minecraft:lure,minecraft:power,minecraft:impaling,minecraft:quick_charge", "minecraft:aqua_affinity,minecraft:depth_strider,minecraft:riptide,unusualfishmod:unusual_catch", "minecraft:thorns,minecraft:piercing", "minecraft:fire_aspect,minecraft:flame", "minecraft:smite,minecraft:projectile_protection"]


### PR DESCRIPTION
closes #934 

disables hellstrider from enchanting table and add to enchants begone so hopefully doesnt appear on books as loot or anything