### PR TITLE
Remove void spellstone from qb reward and advancements

### DIFF
--- a/src/overrides/config/ftbquests/quests/chapters/hard_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/hard_eyes.snbt
@@ -2388,17 +2388,6 @@
 					}
 					type: "item"
 				}
-				{
-					id: "1A622E9240AA8A17"
-					item: {
-						Count: 1b
-						ForgeCaps: {
-							"dungeons_libraries:built_in_enchantments": { }
-						}
-						id: "enigmaticlegacy:void_pearl"
-					}
-					type: "item"
-				}
 			]
 			shape: "rsquare"
 			size: 2.5d

--- a/src/overrides/config/ftbquests/quests/chapters/hard_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/hard_eyes.snbt
@@ -2388,6 +2388,14 @@
 					}
 					type: "item"
 				}
+				{
+					exclude_from_claim_all: true
+					id: "5008E9219153F379"
+					table_id: 8411969201439975834L
+					team_reward: false
+					title: "+1 Inventory Artifact Slot"
+					type: "choice"
+				}
 			]
 			shape: "rsquare"
 			size: 2.5d

--- a/src/overrides/config/ftbquests/quests/chapters/shop.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/shop.snbt
@@ -5289,8 +5289,8 @@
 			shape: "circle"
 			size: 2.0d
 			title: "Other Unlocks"
-			x: 2.25d
-			y: -7.25d
+			x: 2.242346938775512d
+			y: -5.994897959183675d
 		}
 		{
 			can_repeat: true
@@ -5437,8 +5437,8 @@
 				type: "item"
 			}]
 			title: "64x Gems"
-			x: 1.0d
-			y: -6.25d
+			x: 0.5d
+			y: -6.0d
 		}
 		{
 			can_repeat: true
@@ -5509,80 +5509,8 @@
 				type: "item"
 			}]
 			title: "64x Gems"
-			x: 0.5d
-			y: -7.5d
-		}
-		{
-			can_repeat: true
-			dependencies: [
-				"20F2C6E5C8B5D747"
-				"53D0FA1AA4F83273"
-			]
-			disable_toast: true
-			hide: true
-			icon: "enigmaticlegacy:void_pearl"
-			id: "55C27D3B81A52389"
-			rewards: [{
-				id: "4AB8A214FCD00FAE"
-				item: {
-					Count: 1b
-					ForgeCaps: {
-						"dungeons_libraries:built_in_enchantments": { }
-					}
-					id: "enigmaticlegacy:void_pearl"
-				}
-				type: "item"
-			}]
-			subtitle: "64 rubies/jade/aquamarine/onyx"
-			tasks: [{
-				consume_items: true
-				count: 64L
-				disable_toast: true
-				id: "56548129960848EF"
-				item: {
-					Count: 1b
-					ForgeCaps: {
-						"dungeons_libraries:built_in_enchantments": { }
-					}
-					id: "itemfilters:or"
-					tag: {
-						items: [
-							{
-								Count: 1b
-								ForgeCaps: {
-									"dungeons_libraries:built_in_enchantments": { }
-								}
-								id: "epicsamurai:ruby"
-							}
-							{
-								Count: 1b
-								ForgeCaps: {
-									"dungeons_libraries:built_in_enchantments": { }
-								}
-								id: "epicsamurai:jade"
-							}
-							{
-								Count: 1b
-								ForgeCaps: {
-									"dungeons_libraries:built_in_enchantments": { }
-								}
-								id: "epicsamurai:aquamarine"
-							}
-							{
-								Count: 1b
-								ForgeCaps: {
-									"dungeons_libraries:built_in_enchantments": { }
-								}
-								id: "epicsamurai:onyx"
-							}
-						]
-					}
-				}
-				type: "item"
-			}]
-			title: "64x Gems"
-			x: 3.5d
-			y: -6.25d
+			x: 2.25d
+			y: -8.0d
 		}
 		{
 			can_repeat: true
@@ -5654,7 +5582,7 @@
 			}]
 			title: "64x Gems"
 			x: 4.0d
-			y: -7.5d
+			y: -6.0d
 		}
 		{
 			can_repeat: true
@@ -5732,7 +5660,7 @@
 			}]
 			title: "64x Gems"
 			x: 2.25d
-			y: -5.5d
+			y: -4.0d
 		}
 		{
 			can_repeat: true
@@ -5810,7 +5738,7 @@
 			}]
 			title: "64x Gems"
 			x: 2.25d
-			y: -4.25d
+			y: -2.0d
 		}
 		{
 			can_repeat: true

--- a/src/overrides/config/ftbquests/quests/reward_tables/curios_slot.snbt
+++ b/src/overrides/config/ftbquests/quests/reward_tables/curios_slot.snbt
@@ -1,0 +1,24 @@
+{
+	id: "74BD516B915B299A"
+	loot_size: 1
+	order_index: 17
+	rewards: [
+		{
+			command: "/execute at @p run curios add trinkets @p 1"
+			icon: "nameless_trinkets:ice_cube"
+			silent: true
+			team_reward: false
+			title: "Add Trinket"
+			type: "command"
+		}
+		{
+			command: "/execute at @p run curios add charm @p 1"
+			icon: "minecraft:totem_of_undying"
+			silent: true
+			team_reward: false
+			title: "Add Charm"
+			type: "command"
+		}
+	]
+	title: "Curios Slot"
+}

--- a/src/overrides/config/paxi/datapacks/RemoveVoidPearlAdvancements/data/enigmaticlegacy/advancements/book/relics/void_pearl.json
+++ b/src/overrides/config/paxi/datapacks/RemoveVoidPearlAdvancements/data/enigmaticlegacy/advancements/book/relics/void_pearl.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "impossible": {
+        "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/overrides/config/paxi/datapacks/RemoveVoidPearlAdvancements/data/enigmaticlegacy/advancements/main/all_spellstones.json
+++ b/src/overrides/config/paxi/datapacks/RemoveVoidPearlAdvancements/data/enigmaticlegacy/advancements/main/all_spellstones.json
@@ -1,0 +1,74 @@
+{
+  "display": {
+    "icon": {
+      "item": "enigmaticlegacy:enigmatic_item",
+	  "nbt": "{Enchantments: [{lvl: 4s, id: \"minecraft:protection\"}]}"
+    },
+    "title": {
+      "translate": "advancement.enigmaticlegacy:allSpellstones"
+    },
+    "description": {
+      "translate": "advancement.enigmaticlegacy:allSpellstones.desc"
+    },
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "frame": "challenge"
+  },
+  "rewards": {
+    "experience": 200
+  },
+  "parent": "enigmaticlegacy:main/discover_spellstone",
+  "criteria": {
+    "spellstone1": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+             "items": ["enigmaticlegacy:golem_heart"]
+          }
+        ]
+      }
+    },
+	"spellstone2": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+             "items": ["enigmaticlegacy:angel_blessing"]
+          }
+        ]
+      }
+    },
+	"spellstone3": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+             "items": ["enigmaticlegacy:ocean_stone"]
+          }
+        ]
+      }
+    },
+	"spellstone4": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+             "items": ["enigmaticlegacy:blazing_core"]
+          }
+        ]
+      }
+    },
+	"spellstone5": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+             "items": ["enigmaticlegacy:eye_of_nebula"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/overrides/config/paxi/datapacks/RemoveVoidPearlAdvancements/data/enigmaticlegacy/advancements/main/void_pearl.json
+++ b/src/overrides/config/paxi/datapacks/RemoveVoidPearlAdvancements/data/enigmaticlegacy/advancements/main/void_pearl.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "impossible": {
+        "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/overrides/config/paxi/datapacks/RemoveVoidPearlAdvancements/pack.mcmeta
+++ b/src/overrides/config/paxi/datapacks/RemoveVoidPearlAdvancements/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "description": "Removes pearl of the void advancements",
+        "pack_format": 9
+    }
+}

--- a/src/overrides/scripts/hidden-items/void_pearl.zs
+++ b/src/overrides/scripts/hidden-items/void_pearl.zs
@@ -1,0 +1,4 @@
+import mods.jeitweaker.Jei;
+
+// Hide item from showing up in JEI
+Jei.hideIngredient(<item:enigmaticlegacy:void_pearl>);


### PR DESCRIPTION
PR for hiding the Pearl of the Void item from Enigmatic Legacy. Uses a datapack to remove related advancements, a crafttweaker script for hiding the item in JEI, and item is removed as a reward from completing the Wither Eye under Hard Eyes in the QB.

Closes #945 