### PR TITLE
Fix queen bee structure not spawning

### DIFF
--- a/src/overrides/config/paxi/datapacks/queen_bee_jungle/data/queen_bee/tags/worldgen/biome/has_structure/beehive.json
+++ b/src/overrides/config/paxi/datapacks/queen_bee_jungle/data/queen_bee/tags/worldgen/biome/has_structure/beehive.json
@@ -3,9 +3,6 @@
   "values": [
     "minecraft:bamboo_jungle",
     "minecraft:jungle",
-    "minecraft:sparse_jungle",
-    "terralith:jungle_mountains",
-    "terralith:rocky_jungle",
-    "terralith:tropical_jungle"
+    "minecraft:sparse_jungle"
   ]
 }


### PR DESCRIPTION
PR that fixes the queen bee structure not spawning in jungles by removing Terralith biome tags in queen_bee_jungle datapack.

Closes #498 

![image](https://github.com/user-attachments/assets/97280dfd-25bc-43f4-bfca-ddbb22f72f1a)
