### PR TITLE
Feature/bestiary boss dependency

### DIFF
--- a/src/overrides/config/ftbquests/quests/chapters/bestiary.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/bestiary.snbt
@@ -16532,6 +16532,7 @@
 			disable_toast: true
 			icon: "enigmaticlegacy:void_pearl"
 			id: "0CBCB72EE3CED22F"
+			progression_mode: "flexible"
 			size: 2.5d
 			subtitle: "Enter the End, found in the Main End Island at 0,0; resummonable with End Crystals"
 			tasks: [{
@@ -18074,7 +18075,7 @@
 			y: 37.5d
 		}
 		{
-			dependencies: ["0CBCB72EE3CED22F"]
+			dependencies: ["322876A0FCF22949"]
 			disable_toast: true
 			icon: {
 				Count: 1b
@@ -18084,6 +18085,7 @@
 				}
 			}
 			id: "1AE38DDCE49E6258"
+			progression_mode: "flexible"
 			size: 3.5d
 			subtitle: " Click this checkmark to unlock the Postgame Boss Checklist"
 			tasks: [{

--- a/src/overrides/config/ftbquests/quests/chapters/medium_eyes.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/medium_eyes.snbt
@@ -3642,7 +3642,7 @@
 		{
 			dependencies: ["3901079844A43EC1"]
 			description: [
-				"This item can be obtained by killing &4Necromancers&r, an undead minibosses that spawn at night."
+				"This item can be obtained by killing &4Necromancers&r, an undead miniboss that spawns deep underground"
 				""
 				""
 				"The &eNecromancer Staff&r can also be crafted from other &4Necromancers&r drops, &eOrb of the Summoner&r, and &eBone Handle&r, &eNecronium&r."


### PR DESCRIPTION
closes #933 

changes the dependency of the endgame bosses bestiary entry to depend on end instead of killing ender dragon. 

how it was before, even if you killed the enderdragon, if you didnt expand the "end bosses" section then the entire endgame bosses section would remain hidden

also adds a small clarification to necromancer info that it spawns underground