### PR TITLE
blockswap decorated pots with ecologics pots

### DIFF
--- a/src/overrides/config/blockswap/block_swap.json5
+++ b/src/overrides/config/blockswap/block_swap.json5
@@ -85,7 +85,7 @@ to make editing this file much easier.
 	   	}
 	*/
 	"swapper": {
-		"minecraft:decorated_pot": "minecraft:air",
+		"minecraft:decorated_pot": "ecologics:pot",
 		"supplementaries:sack": "minecraft:air",
  		"epicsamurai:silver_ore": "galosphere:silver_ore",
  		"paraglider:goddess_statue": "minecraft:air",

--- a/src/overrides/config/blockswap/block_swap.json5
+++ b/src/overrides/config/blockswap/block_swap.json5
@@ -85,7 +85,8 @@ to make editing this file much easier.
 	   	}
 	*/
 	"swapper": {
-		"supplementaries:sack": "minecraft:air"
+		"minecraft:decorated_pot": "minecraft:air",
+		"supplementaries:sack": "minecraft:air",
  		"epicsamurai:silver_ore": "galosphere:silver_ore",
  		"paraglider:goddess_statue": "minecraft:air",
  		"paraglider:goron_goddess_statue": "minecraft:air",

--- a/src/overrides/config/ftbquests/quests/chapters/bounties.snbt
+++ b/src/overrides/config/ftbquests/quests/chapters/bounties.snbt
@@ -5785,13 +5785,7 @@
 				consume_items: true
 				count: 16L
 				id: "1EAAA67A975758C4"
-				item: {
-					Count: 1b
-					ForgeCaps: {
-						"dungeons_libraries:built_in_enchantments": { }
-					}
-					id: "minecraft:decorated_pot"
-				}
+				item: "ecologics:pot"
 				type: "item"
 			}]
 			x: 19.5d


### PR DESCRIPTION
closes #959 

decorated pots cause the game to crash when broken. so blockswap with air for all new chunks (some cataclysm structures spawn with them)